### PR TITLE
feat: externalize translations and add i18n

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "albert-portfolio",
+  "name": "portafolio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "albert-portfolio",
+      "name": "portafolio",
       "version": "1.0.0",
       "dependencies": {
         "pinia": "^2.1.0",
         "vue": "^3.4.0",
+        "vue-i18n": "^11.1.11",
         "vue-router": "^4.2.0"
       },
       "devDependencies": {
@@ -455,6 +456,50 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@intlify/core-base": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-11.1.11.tgz",
+      "integrity": "sha512-1Z0N8jTfkcD2Luq9HNZt+GmjpFe4/4PpZF3AOzoO1u5PTtSuXZcfhwBatywbfE2ieB/B5QHIoOFmCXY2jqVKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/message-compiler": "11.1.11",
+        "@intlify/shared": "11.1.11"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-11.1.11.tgz",
+      "integrity": "sha512-7PC6neomoc/z7a8JRjPBbu0T2TzR2MQuY5kn2e049MP7+o32Ve7O8husylkA7K9fQRe4iNXZWTPnDJ6vZdtS1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/shared": "11.1.11",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-11.1.11.tgz",
+      "integrity": "sha512-RIBFTIqxZSsxUqlcyoR7iiC632bq7kkOwYvZlvcVObHfrF4NhuKc4FKvu8iPCrEO+e3XsY7/UVpfgzg+M7ETzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1357,6 +1402,26 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-11.1.11.tgz",
+      "integrity": "sha512-LvyteQoXeQiuILbzqv13LbyBna/TEv2Ha+4ZWK2AwGHUzZ8+IBaZS0TJkCgn5izSPLcgZwXy9yyTrewCb2u/MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@intlify/core-base": "11.1.11",
+        "@intlify/shared": "11.1.11",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vue-router": {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
+    "pinia": "^2.1.0",
     "vue": "^3.4.0",
-    "vue-router": "^4.2.0",
-    "pinia": "^2.1.0"
+    "vue-i18n": "^11.1.11",
+    "vue-router": "^4.2.0"
   },
   "devDependencies": {
+    "@types/node": "^20.10.0",
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.3.0",
-    "vue-tsc": "^1.8.0",
     "vite": "^5.0.0",
-    "@types/node": "^20.10.0"
+    "vue-tsc": "^1.8.0"
   }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,51 @@
+{
+  "nav": {
+    "home": "Home",
+    "about": "About",
+    "experience": "Experience",
+    "education": "Education",
+    "skills": "Skills",
+    "projects": "Projects",
+    "contact": "Contact"
+  },
+  "hero": {
+    "greeting": "Hi, I'm",
+    "position": "Front-End Developer",
+    "description": "Front-End Developer with over 3 years of experience building complex enterprise systems. Specialized in Vue.js, TypeScript and modern technologies.",
+    "downloadCV": "Download CV",
+    "contactMe": "Contact Me"
+  },
+  "about": {
+    "title": "About Me",
+    "description": "Front-End Developer with over 3 years of experience building complex enterprise systems for public and private institutions. Expertise in modern technologies like Svelte, Vue.js and TypeScript. Recognized for consistently delivering functional, collaborative and scalable modules.",
+    "goals": {
+      "shortTerm": "Short Term: Advance from semi-senior to senior level, strengthen my technical English and add value to impactful projects.",
+      "longTerm": "Long Term: Work abroad, master emerging technologies like artificial intelligence and specialize in backend microservices."
+    }
+  },
+  "contact": {
+    "title": "Contact",
+    "subtitle": "Let's talk about your next project",
+    "info": "Contact Information",
+    "form": {
+      "title": "Send me a message",
+      "name": "Name",
+      "email": "Email",
+      "subject": "Subject",
+      "message": "Message",
+      "send": "Send Message"
+    }
+  },
+  "footer": {
+    "rights": "All rights reserved",
+    "madeWith": "Made with",
+    "by": "by Albert González"
+  },
+  "notFound": {
+    "title": "Page not found",
+    "description": "Sorry, the page you are looking for does not exist or has been moved.",
+    "goHome": "Go Home",
+    "goBack": "Go Back",
+    "usefulLinks": "Useful Links"
+  }
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,51 @@
+{
+  "nav": {
+    "home": "Inicio",
+    "about": "Sobre Mí",
+    "experience": "Experiencia",
+    "education": "Educación",
+    "skills": "Habilidades",
+    "projects": "Proyectos",
+    "contact": "Contacto"
+  },
+  "hero": {
+    "greeting": "Hola, soy",
+    "position": "Front-End Developer",
+    "description": "Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos. Especializado en Vue.js, TypeScript y tecnologías modernas.",
+    "downloadCV": "Descargar CV",
+    "contactMe": "Contáctame"
+  },
+  "about": {
+    "title": "Sobre Mí",
+    "description": "Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos para instituciones públicas y privadas. Dominio en tecnologías modernas como Svelte, Vue.js y TypeScript. Reconocido por la entrega constante de módulos funcionales, colaborativos y escalables.",
+    "goals": {
+      "shortTerm": "Corto Plazo: Avanzar de nivel semi-senior a senior, fortalecer mi inglés técnico y aportar valor en proyectos con impacto.",
+      "longTerm": "Largo Plazo: Trabajar en el extranjero, dominar tecnologías emergentes como inteligencia artificial y especializarme en microservicios backend."
+    }
+  },
+  "contact": {
+    "title": "Contacto",
+    "subtitle": "Hablemos sobre tu próximo proyecto",
+    "info": "Información de Contacto",
+    "form": {
+      "title": "Envíame un mensaje",
+      "name": "Nombre",
+      "email": "Correo Electrónico",
+      "subject": "Asunto",
+      "message": "Mensaje",
+      "send": "Enviar Mensaje"
+    }
+  },
+  "footer": {
+    "rights": "Todos los derechos reservados",
+    "madeWith": "Hecho con",
+    "by": "por Albert González"
+  },
+  "notFound": {
+    "title": "Página no encontrada",
+    "description": "Lo sentimos, la página que buscas no existe o ha sido movida.",
+    "goHome": "Ir al Inicio",
+    "goBack": "Volver Atrás",
+    "usefulLinks": "Enlaces Útiles"
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,14 @@
+import { createI18n } from 'vue-i18n'
+import en from './en.json'
+import es from './es.json'
+
+export const messages = { en, es }
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'es',
+  fallbackLocale: 'en',
+  messages
+})
+
+export default i18n

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,12 @@ import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
 import './assets/styles/main.css'
+import i18n from './i18n'
 
 const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+app.use(i18n)
 
 app.mount('#app')

--- a/src/stores/main.ts
+++ b/src/stores/main.ts
@@ -1,111 +1,11 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import i18n from '../i18n'
+import es from '../i18n/es.json'
+import en from '../i18n/en.json'
 
 // Translations
-const translations = {
-  es: {
-    nav: {
-      home: 'Inicio',
-      about: 'Sobre Mí',
-      experience: 'Experiencia',
-      education: 'Educación',
-      skills: 'Habilidades',
-      projects: 'Proyectos',
-      contact: 'Contacto'
-    },
-    hero: {
-      greeting: 'Hola, soy',
-      position: 'Front-End Developer',
-      description: 'Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos. Especializado en Vue.js, TypeScript y tecnologías modernas.',
-      downloadCV: 'Descargar CV',
-      contactMe: 'Contáctame'
-    },
-    about: {
-      title: 'Sobre Mí',
-      description: 'Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos para instituciones públicas y privadas. Dominio en tecnologías modernas como Svelte, Vue.js y TypeScript. Reconocido por la entrega constante de módulos funcionales, colaborativos y escalables.',
-      goals: {
-        shortTerm: 'Corto Plazo: Avanzar de nivel semi-senior a senior, fortalecer mi inglés técnico y aportar valor en proyectos con impacto.',
-        longTerm: 'Largo Plazo: Trabajar en el extranjero, dominar tecnologías emergentes como inteligencia artificial y especializarme en microservicios backend.'
-      }
-    },
-    contact: {
-      title: 'Contacto',
-      subtitle: 'Hablemos sobre tu próximo proyecto',
-      info: 'Información de Contacto',
-      form: {
-        title: 'Envíame un mensaje',
-        name: 'Nombre',
-        email: 'Correo Electrónico',
-        subject: 'Asunto',
-        message: 'Mensaje',
-        send: 'Enviar Mensaje'
-      }
-    },
-    footer: {
-      rights: 'Todos los derechos reservados',
-      madeWith: 'Hecho con',
-      by: 'por Albert González'
-    },
-    notFound: {
-      title: 'Página no encontrada',
-      description: 'Lo sentimos, la página que buscas no existe o ha sido movida.',
-      goHome: 'Ir al Inicio',
-      goBack: 'Volver Atrás',
-      usefulLinks: 'Enlaces Útiles'
-    }
-  },
-  en: {
-    nav: {
-      home: 'Home',
-      about: 'About',
-      experience: 'Experience',
-      education: 'Education',
-      skills: 'Skills',
-      projects: 'Projects',
-      contact: 'Contact'
-    },
-    hero: {
-      greeting: 'Hi, I\'m',
-      position: 'Front-End Developer',
-      description: 'Front-End Developer with over 3 years of experience building complex enterprise systems. Specialized in Vue.js, TypeScript and modern technologies.',
-      downloadCV: 'Download CV',
-      contactMe: 'Contact Me'
-    },
-    about: {
-      title: 'About Me',
-      description: 'Front-End Developer with over 3 years of experience building complex enterprise systems for public and private institutions. Expertise in modern technologies like Svelte, Vue.js and TypeScript. Recognized for consistently delivering functional, collaborative and scalable modules.',
-      goals: {
-        shortTerm: 'Short Term: Advance from semi-senior to senior level, strengthen my technical English and add value to impactful projects.',
-        longTerm: 'Long Term: Work abroad, master emerging technologies like artificial intelligence and specialize in backend microservices.'
-      }
-    },
-    contact: {
-      title: 'Contact',
-      subtitle: 'Let\'s talk about your next project',
-      info: 'Contact Information',
-      form: {
-        title: 'Send me a message',
-        name: 'Name',
-        email: 'Email',
-        subject: 'Subject',
-        message: 'Message',
-        send: 'Send Message'
-      }
-    },
-    footer: {
-      rights: 'All rights reserved',
-      madeWith: 'Made with',
-      by: 'by Albert González'
-    },
-    notFound: {
-      title: 'Page not found',
-      description: 'Sorry, the page you are looking for does not exist or has been moved.',
-      goHome: 'Go Home',
-      goBack: 'Go Back',
-      usefulLinks: 'Useful Links'
-    }
-  }
-}
+const translations = { es, en }
 
 export const useMainStore = defineStore('main', () => {
   
@@ -126,10 +26,12 @@ export const useMainStore = defineStore('main', () => {
   // Actions
   const toggleLanguage = () => {
     currentLanguage.value = currentLanguage.value === 'es' ? 'en' : 'es'
+    i18n.global.locale.value = currentLanguage.value
   }
 
   const setLanguage = (lang: 'es' | 'en') => {
     currentLanguage.value = lang
+    i18n.global.locale.value = lang
   }
 
   const toggleDarkMode = () => {


### PR DESCRIPTION
## Summary
- move Spanish and English copy to dedicated JSON files
- initialize vue-i18n plugin and hook it into the app
- import externalized messages in Pinia store and synchronize locale

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68967fbee0b0832d9ef17b2e9c6dddc2