### PR TITLE
Internationalize remaining sections and components

### DIFF
--- a/src/components/ExperienceCard.vue
+++ b/src/components/ExperienceCard.vue
@@ -25,7 +25,7 @@
       <p class="job-description">{{ job.description }}</p>
       
       <div class="achievements">
-        <h5>Logros Principales:</h5>
+        <h5>{{ t.experienceCard.achievements }}</h5>
         <ul class="achievements-list">
           <li v-for="achievement in job.achievements" :key="achievement" class="achievement-item">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="check-icon">
@@ -37,7 +37,7 @@
       </div>
       
       <div class="technologies">
-        <h5>Tecnologías Utilizadas:</h5>
+        <h5>{{ t.experienceCard.technologies }}</h5>
         <div class="tech-icons">
           <template v-for="tech in job.technologies" :key="tech">
             <TechIcon 
@@ -55,8 +55,13 @@
 import type { ExperienceCardProps } from '../interfaces'
 import TechIcon from './TechIcon.vue'
 import technologiesData from '../data/technologies.json'
+import { useMainStore } from '../stores/main'
+import { storeToRefs } from 'pinia'
 
 defineProps<ExperienceCardProps>()
+
+const mainStore = useMainStore()
+const { t } = storeToRefs(mainStore)
 
 // Función para obtener la clave de tecnología desde el nombre
 const getTechKey = (techName: string): keyof typeof technologiesData | null => {

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -8,7 +8,7 @@
             <span class="logo-text">Albert González</span>
           </div>
           <p class="footer-description">
-            Front-End Developer especializado en Vue.js, TypeScript y tecnologías modernas.
+            {{ t.footer.description }}
           </p>
           <div class="social-links">
             <a 
@@ -63,7 +63,7 @@
             </p>
             <p class="contact-item">
               <span class="contact-icon">📍</span>
-              <span>Ciudad de México, México</span>
+              <span>{{ t.footer.location }}</span>
             </p>
           </div>
         </div>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -23,19 +23,19 @@
         <!-- Controls -->
         <div class="navbar-controls">
           <!-- Language Toggle -->
-          <button 
-            @click="toggleLanguage" 
+          <button
+            @click="toggleLanguage"
             class="control-btn language-btn"
-            :title="currentLanguage === 'es' ? 'Switch to English' : 'Cambiar a Español'"
+            :title="currentLanguage === 'es' ? t.navbar.switchToEnglish : t.navbar.switchToSpanish"
           >
             {{ currentLanguage === 'es' ? 'EN' : 'ES' }}
           </button>
 
           <!-- Dark Mode Toggle -->
-          <button 
-            @click="toggleDarkMode" 
+          <button
+            @click="toggleDarkMode"
             class="control-btn theme-btn"
-            :title="isDarkMode ? 'Modo Claro' : 'Modo Oscuro'"
+            :title="isDarkMode ? t.navbar.lightMode : t.navbar.darkMode"
           >
             <span v-if="isDarkMode">☀️</span>
             <span v-else>🌙</span>

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -19,7 +19,7 @@
       <p class="project-description">{{ project.description }}</p>
       
       <div v-if="project.features" class="project-features">
-        <h5>Características Principales:</h5>
+        <h5>{{ t.projectCard.features }}</h5>
         <ul class="features-list">
           <li v-for="feature in project.features" :key="feature" class="feature-item">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="check-icon">
@@ -31,7 +31,7 @@
       </div>
       
       <div class="project-technologies">
-        <h5>Tecnologías Utilizadas:</h5>
+        <h5>{{ t.projectCard.technologies }}</h5>
         <div class="tech-tags">
           <span 
             v-for="tech in project.technologies" 
@@ -69,7 +69,7 @@
           <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
             <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"/>
           </svg>
-          Ver Proyecto
+          {{ t.projectCard.viewProject }}
         </a>
         <a 
           v-if="project.github" 
@@ -89,7 +89,7 @@
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
           <path d="M12,17A2,2 0 0,0 14,15C14,13.89 13.1,13 12,13A2,2 0 0,0 10,15A2,2 0 0,0 12,17M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V10C4,8.89 4.9,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z"/>
         </svg>
-        Proyecto confidencial - {{ project.company }}
+        {{ t.projectCard.confidential }} - {{ project.company }}
       </div>
     </div>
   </div>
@@ -98,8 +98,13 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { ProjectCardProps } from '../interfaces'
+import { useMainStore } from '../stores/main'
+import { storeToRefs } from 'pinia'
 
 const props = defineProps<ProjectCardProps>()
+
+const mainStore = useMainStore()
+const { t } = storeToRefs(mainStore)
 
 const badgeClass = computed(() => {
   const type = props.project.type.toLowerCase()

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -27,16 +27,44 @@
     "title": "Contact",
     "subtitle": "Let's talk about your next project",
     "info": "Contact Information",
+    "details": {
+      "email": "Email",
+      "phone": "Phone",
+      "location": "Location",
+      "linkedin": "LinkedIn"
+    },
+    "follow": "Follow me on:",
+    "cta": {
+      "title": "Ready to work together?",
+      "description": "I'm available for new projects and collaboration opportunities.",
+      "downloadCV": "Download CV",
+      "connectLinkedIn": "Connect on LinkedIn"
+    },
     "form": {
       "title": "Send me a message",
       "name": "Name",
       "email": "Email",
       "subject": "Subject",
       "message": "Message",
-      "send": "Send Message"
+      "send": "Send Message",
+      "sending": "Sending...",
+      "success": "Message sent successfully! I will contact you soon.",
+      "error": "There was an error sending the message. Please try again.",
+      "errors": {
+        "nameRequired": "Name is required",
+        "nameMin": "Name must be at least 2 characters",
+        "emailRequired": "Email is required",
+        "emailInvalid": "Please enter a valid email",
+        "subjectRequired": "Subject is required",
+        "subjectMin": "Subject must be at least 5 characters",
+        "messageRequired": "Message is required",
+        "messageMin": "Message must be at least 10 characters"
+      }
     }
   },
   "footer": {
+    "description": "Front-End Developer specialized in Vue.js, TypeScript and modern technologies.",
+    "location": "Mexico City, Mexico",
     "rights": "All rights reserved",
     "madeWith": "Made with",
     "by": "by Albert González"
@@ -47,5 +75,51 @@
     "goHome": "Go Home",
     "goBack": "Go Back",
     "usefulLinks": "Useful Links"
+  },
+  "education": {
+    "subtitle": "My academic background and professional certifications",
+    "academic": "Academic Education",
+    "studyAreas": "Areas of Study:",
+    "certifications": "Professional Certifications",
+    "philosophy": "Learning Philosophy",
+    "goals": "Learning Goals"
+  },
+  "skills": {
+    "subtitle": "My tech stack and professional competencies",
+    "technical": "Technical Skills",
+    "toolsTech": "Tools & Technologies",
+    "tools": "Tools",
+    "methodologies": "Methodologies",
+    "soft": "Soft Skills"
+  },
+  "projects": {
+    "subtitle": "Featured projects and professional developments",
+    "featured": "Featured Projects",
+    "others": "Other Projects",
+    "stats": "Project Statistics",
+    "completed": "Completed Projects",
+    "technologiesUsed": "Technologies Used",
+    "featuredCount": "Featured Projects",
+    "responsive": "Responsive Design",
+    "techSection": "Technologies in Projects"
+  },
+  "experience": {
+    "subtitle": "My journey in Front-End and Full-Stack development"
+  },
+  "projectCard": {
+    "features": "Main Features:",
+    "technologies": "Technologies Used:",
+    "viewProject": "View Project",
+    "confidential": "Confidential project"
+  },
+  "experienceCard": {
+    "achievements": "Key Achievements:",
+    "technologies": "Technologies Used:"
+  },
+  "navbar": {
+    "switchToEnglish": "Switch to English",
+    "switchToSpanish": "Switch to Spanish",
+    "lightMode": "Light Mode",
+    "darkMode": "Dark Mode"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -27,16 +27,44 @@
     "title": "Contacto",
     "subtitle": "Hablemos sobre tu próximo proyecto",
     "info": "Información de Contacto",
+    "details": {
+      "email": "Email",
+      "phone": "Teléfono",
+      "location": "Ubicación",
+      "linkedin": "LinkedIn"
+    },
+    "follow": "Sígueme en:",
+    "cta": {
+      "title": "¿Listo para trabajar juntos?",
+      "description": "Estoy disponible para nuevos proyectos y oportunidades de colaboración.",
+      "downloadCV": "Descargar CV",
+      "connectLinkedIn": "Conectar en LinkedIn"
+    },
     "form": {
       "title": "Envíame un mensaje",
       "name": "Nombre",
       "email": "Correo Electrónico",
       "subject": "Asunto",
       "message": "Mensaje",
-      "send": "Enviar Mensaje"
+      "send": "Enviar Mensaje",
+      "sending": "Enviando...",
+      "success": "¡Mensaje enviado exitosamente! Te contactaré pronto.",
+      "error": "Hubo un error al enviar el mensaje. Por favor intenta nuevamente.",
+      "errors": {
+        "nameRequired": "El nombre es requerido",
+        "nameMin": "El nombre debe tener al menos 2 caracteres",
+        "emailRequired": "El email es requerido",
+        "emailInvalid": "Por favor ingresa un email válido",
+        "subjectRequired": "El asunto es requerido",
+        "subjectMin": "El asunto debe tener al menos 5 caracteres",
+        "messageRequired": "El mensaje es requerido",
+        "messageMin": "El mensaje debe tener al menos 10 caracteres"
+      }
     }
   },
   "footer": {
+    "description": "Front-End Developer especializado en Vue.js, TypeScript y tecnologías modernas.",
+    "location": "Ciudad de México, México",
     "rights": "Todos los derechos reservados",
     "madeWith": "Hecho con",
     "by": "por Albert González"
@@ -47,5 +75,51 @@
     "goHome": "Ir al Inicio",
     "goBack": "Volver Atrás",
     "usefulLinks": "Enlaces Útiles"
+  },
+  "education": {
+    "subtitle": "Mi formación académica y certificaciones profesionales",
+    "academic": "Formación Académica",
+    "studyAreas": "Áreas de Estudio:",
+    "certifications": "Certificaciones Profesionales",
+    "philosophy": "Filosofía de Aprendizaje",
+    "goals": "Objetivos de Aprendizaje"
+  },
+  "skills": {
+    "subtitle": "Mi stack tecnológico y competencias profesionales",
+    "technical": "Habilidades Técnicas",
+    "toolsTech": "Herramientas y Tecnologías",
+    "tools": "Herramientas",
+    "methodologies": "Metodologías",
+    "soft": "Habilidades Blandas"
+  },
+  "projects": {
+    "subtitle": "Proyectos destacados y desarrollos profesionales",
+    "featured": "Proyectos Destacados",
+    "others": "Otros Proyectos",
+    "stats": "Estadísticas de Proyectos",
+    "completed": "Proyectos Completados",
+    "technologiesUsed": "Tecnologías Utilizadas",
+    "featuredCount": "Proyectos Destacados",
+    "responsive": "Diseño Responsivo",
+    "techSection": "Tecnologías en Proyectos"
+  },
+  "experience": {
+    "subtitle": "Mi trayectoria en el desarrollo Front-End y Full-Stack"
+  },
+  "projectCard": {
+    "features": "Características Principales:",
+    "technologies": "Tecnologías Utilizadas:",
+    "viewProject": "Ver Proyecto",
+    "confidential": "Proyecto confidencial"
+  },
+  "experienceCard": {
+    "achievements": "Logros Principales:",
+    "technologies": "Tecnologías Utilizadas:"
+  },
+  "navbar": {
+    "switchToEnglish": "Cambiar a Inglés",
+    "switchToSpanish": "Cambiar a Español",
+    "lightMode": "Modo Claro",
+    "darkMode": "Modo Oscuro"
   }
 }

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -14,7 +14,7 @@
         <div class="contact-grid">
           <!-- Contact Information -->
           <div class="contact-info animate-fadeInLeft">
-            <h2>Información de Contacto</h2>
+            <h2>{{ t.contact.info }}</h2>
             <div class="info-items">
               <div class="info-item">
                 <div class="info-icon">
@@ -23,7 +23,7 @@
                   </svg>
                 </div>
                 <div class="info-content">
-                  <h3>Email</h3>
+                  <h3>{{ t.contact.details.email }}</h3>
                   <p>albert.gonzalez@email.com</p>
                 </div>
               </div>
@@ -35,7 +35,7 @@
                   </svg>
                 </div>
                 <div class="info-content">
-                  <h3>Teléfono</h3>
+                  <h3>{{ t.contact.details.phone }}</h3>
                   <p>+52 (555) 123-4567</p>
                 </div>
               </div>
@@ -47,8 +47,8 @@
                   </svg>
                 </div>
                 <div class="info-content">
-                  <h3>Ubicación</h3>
-                  <p>Ciudad de México, México</p>
+                  <h3>{{ t.contact.details.location }}</h3>
+                  <p>{{ t.footer.location }}</p>
                 </div>
               </div>
 
@@ -59,7 +59,7 @@
                   </svg>
                 </div>
                 <div class="info-content">
-                  <h3>LinkedIn</h3>
+                  <h3>{{ t.contact.details.linkedin }}</h3>
                   <p>linkedin.com/in/albertglez97</p>
                 </div>
               </div>
@@ -67,7 +67,7 @@
 
             <!-- Social Links -->
             <div class="social-links">
-              <h3>Sígueme en:</h3>
+              <h3>{{ t.contact.follow }}</h3>
               <div class="social-buttons">
                 <a 
                   href="https://www.linkedin.com/in/albertglez97" 
@@ -163,7 +163,7 @@
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" class="loading">
                     <path d="M12,4V2A10,10 0 0,0 2,12H4A8,8 0 0,1 12,4Z"/>
                   </svg>
-                  Enviando...
+                  {{ t.contact.form.sending }}
                 </span>
               </button>
 
@@ -185,8 +185,8 @@
       <!-- Call to Action -->
       <section class="cta-section section">
         <div class="cta-content animate-fadeInUp">
-          <h2>¿Listo para trabajar juntos?</h2>
-          <p>Estoy disponible para nuevos proyectos y oportunidades de colaboración.</p>
+          <h2>{{ t.contact.cta.title }}</h2>
+          <p>{{ t.contact.cta.description }}</p>
           <div class="cta-actions">
             <a 
               href="/CV_Albert_Gonzalez.pdf" 
@@ -196,15 +196,15 @@
               <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
               </svg>
-              Descargar CV
+              {{ t.contact.cta.downloadCV }}
             </a>
-            <a 
-              href="https://www.linkedin.com/in/albertglez97" 
-              target="_blank" 
+            <a
+              href="https://www.linkedin.com/in/albertglez97"
+              target="_blank"
               rel="noopener noreferrer"
               class="btn btn-primary"
             >
-              Conectar en LinkedIn
+              {{ t.contact.cta.connectLinkedIn }}
             </a>
           </div>
         </div>
@@ -258,37 +258,37 @@ const validateForm = (): boolean => {
 
   // Name validation
   if (!form.name.trim()) {
-    errors.name = 'El nombre es requerido'
+    errors.name = t.value.contact.form.errors.nameRequired
     isValid = false
   } else if (form.name.trim().length < 2) {
-    errors.name = 'El nombre debe tener al menos 2 caracteres'
+    errors.name = t.value.contact.form.errors.nameMin
     isValid = false
   }
 
   // Email validation
   if (!form.email.trim()) {
-    errors.email = 'El email es requerido'
+    errors.email = t.value.contact.form.errors.emailRequired
     isValid = false
   } else if (!validateEmail(form.email)) {
-    errors.email = 'Por favor ingresa un email válido'
+    errors.email = t.value.contact.form.errors.emailInvalid
     isValid = false
   }
 
   // Subject validation
   if (!form.subject.trim()) {
-    errors.subject = 'El asunto es requerido'
+    errors.subject = t.value.contact.form.errors.subjectRequired
     isValid = false
   } else if (form.subject.trim().length < 5) {
-    errors.subject = 'El asunto debe tener al menos 5 caracteres'
+    errors.subject = t.value.contact.form.errors.subjectMin
     isValid = false
   }
 
   // Message validation
   if (!form.message.trim()) {
-    errors.message = 'El mensaje es requerido'
+    errors.message = t.value.contact.form.errors.messageRequired
     isValid = false
   } else if (form.message.trim().length < 10) {
-    errors.message = 'El mensaje debe tener al menos 10 caracteres'
+    errors.message = t.value.contact.form.errors.messageMin
     isValid = false
   }
 
@@ -310,7 +310,7 @@ const handleSubmit = async () => {
     
     // Simulate success
     submitStatus.value = 'success'
-    submitMessage.value = '¡Mensaje enviado exitosamente! Te contactaré pronto.'
+    submitMessage.value = t.value.contact.form.success
     
     // Reset form
     Object.keys(form).forEach(key => {
@@ -319,7 +319,7 @@ const handleSubmit = async () => {
     
   } catch (error) {
     submitStatus.value = 'error'
-    submitMessage.value = 'Hubo un error al enviar el mensaje. Por favor intenta nuevamente.'
+    submitMessage.value = t.value.contact.form.error
   } finally {
     isSubmitting.value = false
     

--- a/src/views/Education.vue
+++ b/src/views/Education.vue
@@ -5,13 +5,13 @@
       <section class="education-hero section">
         <div class="hero-content animate-fadeInUp">
           <h1 class="section-title">{{ t.nav.education }}</h1>
-          <p class="hero-subtitle">Mi formación académica y certificaciones profesionales</p>
+          <p class="hero-subtitle">{{ t.education.subtitle }}</p>
         </div>
       </section>
 
       <!-- Academic Education -->
       <section class="academic-section section">
-        <h2 class="section-title">Formación Académica</h2>
+        <h2 class="section-title">{{ t.education.academic }}</h2>
         <div class="education-card main-degree animate-fadeInUp">
           <div class="card-header">
             <div class="degree-info">
@@ -40,7 +40,7 @@
             <p class="degree-description">{{ educationData.academic.description }}</p>
             
             <div class="subjects-covered">
-              <h5>Áreas de Estudio:</h5>
+              <h5>{{ t.education.studyAreas }}</h5>
               <div class="subjects-grid">
                 <div 
                   v-for="subject in educationData.academic.subjects" 
@@ -65,7 +65,7 @@
 
       <!-- Professional Certifications -->
       <section class="certifications-section section">
-        <h2 class="section-title">Certificaciones Profesionales</h2>
+        <h2 class="section-title">{{ t.education.certifications }}</h2>
         <div class="certifications-grid">
           <CertificationCard 
             v-for="certification in educationData.certifications" 
@@ -79,7 +79,7 @@
       <!-- Learning Philosophy -->
       <section class="philosophy-section section">
         <div class="philosophy-content">
-          <h2 class="section-title">Filosofía de Aprendizaje</h2>
+          <h2 class="section-title">{{ t.education.philosophy }}</h2>
           <div class="philosophy-grid">
             <div 
               v-for="philosophy in educationData.philosophy" 
@@ -103,7 +103,7 @@
       <!-- Future Learning Goals -->
       <section class="future-goals-section section">
         <div class="goals-content">
-          <h2 class="section-title">Objetivos de Aprendizaje</h2>
+          <h2 class="section-title">{{ t.education.goals }}</h2>
           <div class="goals-timeline">
             <div 
               v-for="goal in educationData.goals" 

--- a/src/views/Experience.vue
+++ b/src/views/Experience.vue
@@ -5,7 +5,7 @@
       <section class="experience-hero section">
         <div class="hero-content animate-fadeInUp">
           <h1 class="section-title">{{ t.nav.experience }}</h1>
-          <p class="hero-subtitle">Mi trayectoria en el desarrollo Front-End y Full-Stack</p>
+          <p class="hero-subtitle">{{ t.experience.subtitle }}</p>
         </div>
       </section>
 

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -5,13 +5,13 @@
       <section class="projects-hero section">
         <div class="hero-content animate-fadeInUp">
           <h1 class="section-title">{{ t.nav.projects }}</h1>
-          <p class="hero-subtitle">Proyectos destacados y desarrollos profesionales</p>
+          <p class="hero-subtitle">{{ t.projects.subtitle }}</p>
         </div>
       </section>
 
       <!-- Featured Projects -->
       <section class="featured-projects section">
-        <h2 class="section-title">Proyectos Destacados</h2>
+        <h2 class="section-title">{{ t.projects.featured }}</h2>
         <div class="projects-grid featured">
           <ProjectCard 
             v-for="project in projectsData.featured" 
@@ -24,7 +24,7 @@
 
       <!-- Other Projects -->
       <section class="other-projects section">
-        <h2 class="section-title">Otros Proyectos</h2>
+        <h2 class="section-title">{{ t.projects.others }}</h2>
         <div class="projects-grid">
           <ProjectCard 
             v-for="project in projectsData.other" 
@@ -38,7 +38,7 @@
       <!-- Project Stats -->
       <section class="project-stats section">
         <div class="stats-content">
-          <h2 class="section-title">Estadísticas de Proyectos</h2>
+          <h2 class="section-title">{{ t.projects.stats }}</h2>
           <div class="stats-grid">
             <div class="stat-item animate-fadeInUp">
               <div class="stat-icon">
@@ -47,7 +47,7 @@
                 </svg>
               </div>
               <div class="stat-number">{{ totalProjects }}</div>
-              <div class="stat-label">Proyectos Completados</div>
+              <div class="stat-label">{{ t.projects.completed }}</div>
             </div>
 
             <div class="stat-item animate-fadeInUp">
@@ -57,7 +57,7 @@
                 </svg>
               </div>
               <div class="stat-number">{{ uniqueTechnologies }}</div>
-              <div class="stat-label">Tecnologías Utilizadas</div>
+              <div class="stat-label">{{ t.projects.technologiesUsed }}</div>
             </div>
 
             <div class="stat-item animate-fadeInUp">
@@ -67,7 +67,7 @@
                 </svg>
               </div>
               <div class="stat-number">{{ featuredProjects }}</div>
-              <div class="stat-label">Proyectos Destacados</div>
+              <div class="stat-label">{{ t.projects.featuredCount }}</div>
             </div>
 
             <div class="stat-item animate-fadeInUp">
@@ -77,7 +77,7 @@
                 </svg>
               </div>
               <div class="stat-number">100%</div>
-              <div class="stat-label">Responsive Design</div>
+              <div class="stat-label">{{ t.projects.responsive }}</div>
             </div>
           </div>
         </div>
@@ -86,7 +86,7 @@
       <!-- Technologies Used -->
       <section class="technologies-section section">
         <div class="tech-content">
-          <h2 class="section-title">Tecnologías en Proyectos</h2>
+          <h2 class="section-title">{{ t.projects.techSection }}</h2>
           <div class="tech-cloud">
             <template v-for="tech in allTechnologies" :key="tech.name">
               <TechIcon 

--- a/src/views/Skills.vue
+++ b/src/views/Skills.vue
@@ -5,13 +5,13 @@
       <section class="skills-hero section">
         <div class="hero-content animate-fadeInUp">
           <h1 class="section-title">{{ t.nav.skills }}</h1>
-          <p class="hero-subtitle">Mi stack tecnológico y competencias profesionales</p>
+          <p class="hero-subtitle">{{ t.skills.subtitle }}</p>
         </div>
       </section>
 
       <!-- Technical Skills -->
       <section class="technical-skills section">
-        <h2 class="section-title">Habilidades Técnicas</h2>
+        <h2 class="section-title">{{ t.skills.technical }}</h2>
         <div class="skills-grid">
           <!-- Frontend Skills -->
           <div class="skill-category">
@@ -54,7 +54,7 @@
       <!-- Tools & Technologies -->
       <section class="tools-section section">
         <div class="tools-content">
-          <h2 class="section-title">Herramientas y Tecnologías</h2>
+          <h2 class="section-title">{{ t.skills.toolsTech }}</h2>
           <div class="tools-grid">
             <div class="tool-category">
               <div class="category-icon">
@@ -62,7 +62,7 @@
                   <path d="M12,2A3,3 0 0,1 15,5V11A3,3 0 0,1 12,14A3,3 0 0,1 9,11V5A3,3 0 0,1 12,2Z"/>
                 </svg>
               </div>
-              <h3>Herramientas</h3>
+              <h3>{{ t.skills.tools }}</h3>
               <div class="tools-list">
                 <span 
                   v-for="tool in skillsData.tools" 
@@ -81,7 +81,7 @@
                   <path d="M16,4C18.11,4 20.11,4.89 21.61,6.39C23.11,7.89 24,9.89 24,12A8,8 0 0,1 16,20H5A5,5 0 0,1 0,15A5,5 0 0,1 5,10C5.59,10 6.16,10.13 6.69,10.36C7.61,7.24 10.57,5 14,5C14.68,5 15.34,5.11 16,5.28V4Z"/>
                 </svg>
               </div>
-              <h3>Metodologías</h3>
+              <h3>{{ t.skills.methodologies }}</h3>
               <div class="tools-list">
                 <span 
                   v-for="methodology in skillsData.methodologies" 
@@ -99,7 +99,7 @@
 
       <!-- Soft Skills -->
       <section class="soft-skills section">
-        <h2 class="section-title">Habilidades Blandas</h2>
+        <h2 class="section-title">{{ t.skills.soft }}</h2>
         <div class="soft-skills-grid">
           <div 
             v-for="skill in skillsData.soft" 


### PR DESCRIPTION
## Summary
- Replace hardcoded Spanish text in contact view, social links, and call-to-action using translation keys.
- Localize footer, project and experience cards, and add translations across education, skills, projects, and experience views.
- Expand English and Spanish dictionaries with new sections and navbar tooltips.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968bbc41bc832d998397f84cc25705