### PR TITLE
feat: add multilingual skill data

### DIFF
--- a/src/components/SkillBar.vue
+++ b/src/components/SkillBar.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="skill-bar">
     <div class="skill-info">
-      <span class="skill-name">{{ skill.name }}</span>
-      <span class="skill-level" :class="levelClass">{{ skill.level }}</span>
+      <span class="skill-name">{{ skill.name[currentLanguage] }}</span>
+      <span class="skill-level" :class="levelClass">{{ skill.level[currentLanguage] }}</span>
     </div>
     <div class="progress-bar">
       <div 
@@ -15,12 +15,17 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useMainStore } from '../stores/main'
 import type { SkillBarProps } from '../interfaces'
 
 const props = defineProps<SkillBarProps>()
 
+const mainStore = useMainStore()
+const { currentLanguage } = storeToRefs(mainStore)
+
 const levelClass = computed(() => {
-  const level = props.skill.level.toLowerCase()
+  const level = props.skill.level[currentLanguage.value].toLowerCase()
   if (level.includes('experto') || level.includes('expert')) return 'expert'
   if (level.includes('avanzado') || level.includes('advanced')) return 'advanced'
   if (level.includes('intermedio') || level.includes('intermediate')) return 'intermediate'

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -2,152 +2,219 @@
   "technical": {
     "frontend": [
       {
-        "name": "Vue.js",
-        "level": "Avanzado",
+        "name": { "es": "Vue.js", "en": "Vue.js" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 90,
         "icon": "vue",
-        "description": "Framework progresivo para construir interfaces de usuario"
+        "description": {
+          "es": "Framework progresivo para construir interfaces de usuario",
+          "en": "Progressive framework for building user interfaces"
+        }
       },
       {
-        "name": "Svelte",
-        "level": "Avanzado", 
+        "name": { "es": "Svelte", "en": "Svelte" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 85,
         "icon": "svelte",
-        "description": "Framework moderno para aplicaciones web rápidas"
+        "description": {
+          "es": "Framework moderno para aplicaciones web rápidas",
+          "en": "Modern framework for fast web applications"
+        }
       },
       {
-        "name": "TypeScript",
-        "level": "Avanzado",
+        "name": { "es": "TypeScript", "en": "TypeScript" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 85,
         "icon": "typescript",
-        "description": "JavaScript con tipado estático para mejor desarrollo"
+        "description": {
+          "es": "JavaScript con tipado estático para mejor desarrollo",
+          "en": "JavaScript with static typing for better development"
+        }
       },
       {
-        "name": "JavaScript",
-        "level": "Experto",
+        "name": { "es": "JavaScript", "en": "JavaScript" },
+        "level": { "es": "Experto", "en": "Expert" },
         "percentage": 95,
         "icon": "javascript",
-        "description": "Lenguaje de programación fundamental para web"
+        "description": {
+          "es": "Lenguaje de programación fundamental para web",
+          "en": "Fundamental programming language for the web"
+        }
       },
       {
-        "name": "HTML5",
-        "level": "Experto",
+        "name": { "es": "HTML5", "en": "HTML5" },
+        "level": { "es": "Experto", "en": "Expert" },
         "percentage": 95,
         "icon": "html",
-        "description": "Lenguaje de marcado para estructurar contenido web"
+        "description": {
+          "es": "Lenguaje de marcado para estructurar contenido web",
+          "en": "Markup language for structuring web content"
+        }
       },
       {
-        "name": "CSS3 / Sass",
-        "level": "Avanzado",
+        "name": { "es": "CSS3 / Sass", "en": "CSS3 / Sass" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 90,
         "icon": "css",
-        "description": "Estilos y preprocesadores para diseño web"
+        "description": {
+          "es": "Estilos y preprocesadores para diseño web",
+          "en": "Styles and preprocessors for web design"
+        }
       },
       {
-        "name": "Bootstrap",
-        "level": "Avanzado",
+        "name": { "es": "Bootstrap", "en": "Bootstrap" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 85,
         "icon": "bootstrap",
-        "description": "Framework CSS para desarrollo responsive"
+        "description": {
+          "es": "Framework CSS para desarrollo responsive",
+          "en": "CSS framework for responsive development"
+        }
       }
     ],
     "backend": [
       {
-        "name": ".NET 6 MVC",
-        "level": "Intermedio",
+        "name": { "es": ".NET 6 MVC", "en": ".NET 6 MVC" },
+        "level": { "es": "Intermedio", "en": "Intermediate" },
         "percentage": 50,
         "icon": "dotnet",
-        "description": "Framework para aplicaciones web robustas"
+        "description": {
+          "es": "Framework para aplicaciones web robustas",
+          "en": "Framework for robust web applications"
+        }
       },
       {
-        "name": "APIs RESTful",
-        "level": "Avanzado",
+        "name": { "es": "APIs RESTful", "en": "RESTful APIs" },
+        "level": { "es": "Avanzado", "en": "Advanced" },
         "percentage": 85,
         "icon": "api",
-        "description": "Diseño e implementación de servicios web"
+        "description": {
+          "es": "Diseño e implementación de servicios web",
+          "en": "Design and implementation of web services"
+        }
       },
       {
-        "name": "SQL Server",
-        "level": "Intermedio",
+        "name": { "es": "SQL Server", "en": "SQL Server" },
+        "level": { "es": "Intermedio", "en": "Intermediate" },
         "percentage": 70,
         "icon": "database",
-        "description": "Base de datos relacional de Microsoft"
+        "description": {
+          "es": "Base de datos relacional de Microsoft",
+          "en": "Microsoft relational database"
+        }
       },
       {
-        "name": "Node.js",
-        "level": "Intermedio",
+        "name": { "es": "Node.js", "en": "Node.js" },
+        "level": { "es": "Intermedio", "en": "Intermediate" },
         "percentage": 75,
         "icon": "nodejs",
-        "description": "Runtime de JavaScript para backend"
+        "description": {
+          "es": "Runtime de JavaScript para backend",
+          "en": "JavaScript runtime for backend"
+        }
       }
     ]
   },
   "tools": [
     {
-      "name": "Git",
-      "level": "Avanzado",
+      "name": { "es": "Git", "en": "Git" },
+      "level": { "es": "Avanzado", "en": "Advanced" },
       "icon": "git",
-      "description": "Control de versiones distribuido"
+      "description": {
+        "es": "Control de versiones distribuido",
+        "en": "Distributed version control"
+      }
     },
     {
-      "name": "GitLab",
-      "level": "Avanzado", 
+      "name": { "es": "GitLab", "en": "GitLab" },
+      "level": { "es": "Avanzado", "en": "Advanced" },
       "icon": "gitlab",
-      "description": "Plataforma DevOps completa"
+      "description": {
+        "es": "Plataforma DevOps completa",
+        "en": "Complete DevOps platform"
+      }
     },
     {
-      "name": "Docker",
-      "level": "Intermedio",
+      "name": { "es": "Docker", "en": "Docker" },
+      "level": { "es": "Intermedio", "en": "Intermediate" },
       "icon": "docker",
-      "description": "Containerización de aplicaciones"
+      "description": {
+        "es": "Containerización de aplicaciones",
+        "en": "Application containerization"
+      }
     },
     {
-      "name": "Selenium",
-      "level": "Intermedio",
+      "name": { "es": "Selenium", "en": "Selenium" },
+      "level": { "es": "Intermedio", "en": "Intermediate" },
       "icon": "selenium",
-      "description": "Automatización de pruebas web"
+      "description": {
+        "es": "Automatización de pruebas web",
+        "en": "Web testing automation"
+      }
     }
   ],
   "methodologies": [
     {
-      "name": "Scrum",
-      "level": "Avanzado",
+      "name": { "es": "Scrum", "en": "Scrum" },
+      "level": { "es": "Avanzado", "en": "Advanced" },
       "icon": "scrum",
-      "description": "Marco de trabajo ágil para desarrollo"
+      "description": {
+        "es": "Marco de trabajo ágil para desarrollo",
+        "en": "Agile framework for development"
+      }
     },
     {
-      "name": "Redux",
-      "level": "Avanzado",
-      "icon": "redux", 
-      "description": "Gestión de estado predecible"
+      "name": { "es": "Redux", "en": "Redux" },
+      "level": { "es": "Avanzado", "en": "Advanced" },
+      "icon": "redux",
+      "description": {
+        "es": "Gestión de estado predecible",
+        "en": "Predictable state management"
+      }
     },
     {
-      "name": "Responsive Design",
-      "level": "Experto",
+      "name": { "es": "Responsive Design", "en": "Responsive Design" },
+      "level": { "es": "Experto", "en": "Expert" },
       "icon": "responsive",
-      "description": "Diseño adaptativo para múltiples dispositivos"
+      "description": {
+        "es": "Diseño adaptativo para múltiples dispositivos",
+        "en": "Adaptive design for multiple devices"
+      }
     }
   ],
   "soft": [
     {
-      "name": "Comunicación Efectiva",
+      "name": { "es": "Comunicación Efectiva", "en": "Effective Communication" },
       "icon": "communication",
-      "description": "Clara al explicar soluciones técnicas a clientes y analistas"
+      "description": {
+        "es": "Clara al explicar soluciones técnicas a clientes y analistas",
+        "en": "Clear when explaining technical solutions to clients and analysts"
+      }
     },
     {
-      "name": "Trabajo en Equipo", 
+      "name": { "es": "Trabajo en Equipo", "en": "Teamwork" },
       "icon": "teamwork",
-      "description": "Colaborativo con equipos multidisciplinarios y apoyo entre áreas"
+      "description": {
+        "es": "Colaborativo con equipos multidisciplinarios y apoyo entre áreas",
+        "en": "Collaborative with multidisciplinary teams and supportive across areas"
+      }
     },
     {
-      "name": "Pensamiento Analítico",
+      "name": { "es": "Pensamiento Analítico", "en": "Analytical Thinking" },
       "icon": "analytics",
-      "description": "Solución práctica a requerimientos complejos"
+      "description": {
+        "es": "Solución práctica a requerimientos complejos",
+        "en": "Practical approach to solving complex requirements"
+      }
     },
     {
-      "name": "Gestión del Tiempo",
+      "name": { "es": "Gestión del Tiempo", "en": "Time Management" },
       "icon": "time",
-      "description": "Cumplimiento puntual de entregas y documentación de avances"
+      "description": {
+        "es": "Cumplimiento puntual de entregas y documentación de avances",
+        "en": "Timely fulfillment of deliverables and progress documentation"
+      }
     }
   ]
 }
+

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -117,7 +117,9 @@
     "toolsTech": "Tools & Technologies",
     "tools": "Tools",
     "methodologies": "Methodologies",
-    "soft": "Soft Skills"
+    "soft": "Soft Skills",
+    "frontend": "Frontend Development",
+    "backend": "Backend Development"
   },
   "projects": {
     "subtitle": "Featured projects and professional developments",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -117,7 +117,9 @@
     "toolsTech": "Herramientas y Tecnologías",
     "tools": "Herramientas",
     "methodologies": "Metodologías",
-    "soft": "Habilidades Blandas"
+    "soft": "Habilidades Blandas",
+    "frontend": "Desarrollo Frontend",
+    "backend": "Desarrollo Backend"
   },
   "projects": {
     "subtitle": "Proyectos destacados y desarrollos profesionales",

--- a/src/interfaces/Skills.ts
+++ b/src/interfaces/Skills.ts
@@ -1,29 +1,31 @@
+import type { MultiLanguageText } from './Personal'
+
 export interface Skill {
-  name: string
-  level: string
+  name: MultiLanguageText
+  level: MultiLanguageText
   percentage: number
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface Tool {
-  name: string
-  level: string
+  name: MultiLanguageText
+  level: MultiLanguageText
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface Methodology {
-  name: string
-  level: string
+  name: MultiLanguageText
+  level: MultiLanguageText
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface SoftSkill {
-  name: string
+  name: MultiLanguageText
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface TechnicalSkills {

--- a/src/stores/skills.ts
+++ b/src/stores/skills.ts
@@ -25,11 +25,19 @@ export const useSkillsStore = defineStore('skills', () => {
   // Actions
   const getSkillByName = (name: string) => {
     const allSkills = [...skills.technical.frontend, ...skills.technical.backend]
-    return allSkills.find(skill => skill.name.toLowerCase() === name.toLowerCase())
+    return allSkills.find(
+      skill =>
+        skill.name.es.toLowerCase() === name.toLowerCase() ||
+        skill.name.en.toLowerCase() === name.toLowerCase()
+    )
   }
 
   const getToolByName = (name: string) => {
-    return skills.tools.find(tool => tool.name.toLowerCase() === name.toLowerCase())
+    return skills.tools.find(
+      tool =>
+        tool.name.es.toLowerCase() === name.toLowerCase() ||
+        tool.name.en.toLowerCase() === name.toLowerCase()
+    )
   }
 
   return {

--- a/src/views/Skills.vue
+++ b/src/views/Skills.vue
@@ -19,13 +19,13 @@
               <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M4,6H20V16H4M20,18A2,2 0 0,0 22,16V6C22,4.89 21.1,4 20,4H4C2.89,4 2,4.89 2,6V16A2,2 0 0,0 4,18H0V20H24V18H20Z"/>
               </svg>
-              <h3>Frontend Development</h3>
+              <h3>{{ t.skills.frontend }}</h3>
             </div>
             
             <div class="skills-list">
               <SkillBar 
-                v-for="skill in skillsData.technical.frontend" 
-                :key="skill.name"
+                v-for="skill in skillsData.technical.frontend"
+                :key="skill.name.en"
                 :skill="skill"
               />
             </div>
@@ -37,13 +37,13 @@
               <svg width="40" height="40" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M4,6H20V16H4M20,18A2,2 0 0,0 22,16V6C22,4.89 21.1,4 20,4H4C2.89,4 2,4.89 2,6V16A2,2 0 0,0 4,18H0V20H24V18H20Z"/>
               </svg>
-              <h3>Backend Development</h3>
+              <h3>{{ t.skills.backend }}</h3>
             </div>
             
             <div class="skills-list">
               <SkillBar 
-                v-for="skill in skillsData.technical.backend" 
-                :key="skill.name"
+                v-for="skill in skillsData.technical.backend"
+                :key="skill.name.en"
                 :skill="skill"
               />
             </div>
@@ -65,12 +65,12 @@
               <h3>{{ t.skills.tools }}</h3>
               <div class="tools-list">
                 <span 
-                  v-for="tool in skillsData.tools" 
-                  :key="tool.name"
+                  v-for="tool in skillsData.tools"
+                  :key="tool.name.en"
                   class="tool-tag"
-                  :title="tool.description"
+                  :title="tool.description[currentLanguage]"
                 >
-                  {{ tool.name }}
+                  {{ tool.name[currentLanguage] }}
                 </span>
               </div>
             </div>
@@ -84,12 +84,12 @@
               <h3>{{ t.skills.methodologies }}</h3>
               <div class="tools-list">
                 <span 
-                  v-for="methodology in skillsData.methodologies" 
-                  :key="methodology.name"
+                  v-for="methodology in skillsData.methodologies"
+                  :key="methodology.name.en"
                   class="tool-tag"
-                  :title="methodology.description"
+                  :title="methodology.description[currentLanguage]"
                 >
-                  {{ methodology.name }}
+                  {{ methodology.name[currentLanguage] }}
                 </span>
               </div>
             </div>
@@ -102,8 +102,8 @@
         <h2 class="section-title">{{ t.skills.soft }}</h2>
         <div class="soft-skills-grid">
           <div 
-            v-for="skill in skillsData.soft" 
-            :key="skill.name"
+            v-for="skill in skillsData.soft"
+            :key="skill.name.en"
             class="soft-skill-item animate-fadeInUp"
           >
             <div class="skill-icon">
@@ -115,8 +115,8 @@
               </svg>
             </div>
             <div class="skill-content">
-              <h3>{{ skill.name }}</h3>
-              <p>{{ skill.description }}</p>
+              <h3>{{ skill.name[currentLanguage] }}</h3>
+              <p>{{ skill.description[currentLanguage] }}</p>
             </div>
           </div>
         </div>
@@ -134,7 +134,7 @@ import type { SkillsData } from '../interfaces'
 
 const mainStore = useMainStore()
 const skillsStore = useSkillsStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
 const { getSkills } = storeToRefs(skillsStore)
 const skillsData: SkillsData = getSkills.value
 </script>


### PR DESCRIPTION
## Summary
- add es/en fields for all skills and tools
- localize skill categories and display translations based on current language

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689696bee9e0832da0a81280d12b91f2