### PR TITLE
feat: add bilingual content and i18n support

### DIFF
--- a/src/components/CertificationCard.vue
+++ b/src/components/CertificationCard.vue
@@ -16,15 +16,19 @@
         <span class="badge-text">{{ certification.provider }}</span>
       </div>
     </div>
-    <h3>{{ certification.title }}</h3>
-    <p>{{ certification.description }}</p>
+    <h3>{{ getTranslatedText(certification.title) }}</h3>
+    <p>{{ getTranslatedText(certification.description) }}</p>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { CertificationCardProps } from '../interfaces'
+import { useMainStore } from '../stores/main'
 
 defineProps<CertificationCardProps>()
+
+const mainStore = useMainStore()
+const { getTranslatedText } = mainStore
 </script>
 
 <style scoped>

--- a/src/components/ExperienceCard.vue
+++ b/src/components/ExperienceCard.vue
@@ -10,28 +10,28 @@
           </svg>
         </div>
         <div class="job-details">
-          <h3>{{ job.title }}</h3>
+          <h3>{{ getTranslatedText(job.title) }}</h3>
           <h4>{{ job.company }}</h4>
           <div class="job-meta">
-            <span class="period">{{ job.period }}</span>
-            <span v-if="job.type === 'current'" class="status current">{{ job.duration }}</span>
-            <span v-else class="status">{{ job.duration }}</span>
+            <span class="period">{{ getTranslatedText(job.period) }}</span>
+            <span v-if="job.type === 'current'" class="status current">{{ getTranslatedText(job.duration) }}</span>
+            <span v-else class="status">{{ getTranslatedText(job.duration) }}</span>
           </div>
         </div>
       </div>
     </div>
     
     <div class="card-content">
-      <p class="job-description">{{ job.description }}</p>
+      <p class="job-description">{{ getTranslatedText(job.description) }}</p>
       
       <div class="achievements">
         <h5>{{ t.experienceCard.achievements }}</h5>
         <ul class="achievements-list">
-          <li v-for="achievement in job.achievements" :key="achievement" class="achievement-item">
+          <li v-for="achievement in job.achievements" :key="achievement.en" class="achievement-item">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="check-icon">
               <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
             </svg>
-            {{ achievement }}
+            {{ getTranslatedText(achievement) }}
           </li>
         </ul>
       </div>
@@ -62,6 +62,7 @@ defineProps<ExperienceCardProps>()
 
 const mainStore = useMainStore()
 const { t } = storeToRefs(mainStore)
+const { getTranslatedText } = mainStore
 
 // Función para obtener la clave de tecnología desde el nombre
 const getTechKey = (techName: string): keyof typeof technologiesData | null => {

--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="project-card" :class="{ 'featured': project.type === 'Destacado' }">
+  <div class="project-card" :class="{ 'featured': badgeClass === 'featured' }">
     <div class="project-image">
       <div class="image-placeholder">
         <svg width="60" height="60" viewBox="0 0 24 24" fill="currentColor">
@@ -10,22 +10,22 @@
     
     <div class="project-content">
       <div class="project-header">
-        <h3>{{ project.title }}</h3>
+        <h3>{{ getTranslatedText(project.title) }}</h3>
         <span v-if="project.type" class="project-badge" :class="badgeClass">
-          {{ project.type }}
+          {{ getTranslatedText(project.type) }}
         </span>
       </div>
       
-      <p class="project-description">{{ project.description }}</p>
+      <p class="project-description">{{ getTranslatedText(project.description) }}</p>
       
       <div v-if="project.features" class="project-features">
         <h5>{{ t.projectCard.features }}</h5>
         <ul class="features-list">
-          <li v-for="feature in project.features" :key="feature" class="feature-item">
+          <li v-for="feature in project.features" :key="feature.en" class="feature-item">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="check-icon">
               <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
             </svg>
-            {{ feature }}
+            {{ getTranslatedText(feature) }}
           </li>
         </ul>
       </div>
@@ -53,7 +53,7 @@
           <span class="metric-label">Performance</span>
         </div>
         <div class="metric">
-          <span class="metric-value">{{ project.metrics.seo }}</span>
+          <span class="metric-value">{{ getTranslatedText(project.metrics.seo) }}</span>
           <span class="metric-label">SEO</span>
         </div>
       </div>
@@ -105,11 +105,13 @@ const props = defineProps<ProjectCardProps>()
 
 const mainStore = useMainStore()
 const { t } = storeToRefs(mainStore)
+const { getTranslatedText } = mainStore
 
 const badgeClass = computed(() => {
-  const type = props.project.type.toLowerCase()
-  if (type.includes('destacado') || type.includes('featured')) return 'featured'
-  if (type.includes('profesional') || type.includes('professional')) return 'professional'
+  const typeEs = props.project.type.es.toLowerCase()
+  const typeEn = props.project.type.en.toLowerCase()
+  if (typeEs.includes('destacado') || typeEn.includes('featured')) return 'featured'
+  if (typeEs.includes('profesional') || typeEn.includes('professional')) return 'professional'
   return 'default'
 })
 </script>

--- a/src/data/education.json
+++ b/src/data/education.json
@@ -1,123 +1,147 @@
 {
   "academic": {
-    "degree": "Ingeniería en Informática",
+    "degree": { "es": "Ingeniería en Informática", "en": "Computer Engineering" },
     "institution": "Tecnológico de Estudios Superiores de Ecatepec",
     "period": "2016 - 2022",
-    "status": "Titulado",
-    "description": "Formación sólida en desarrollo de software, bases de datos, metodologías de desarrollo y fundamentos de la informática. Titulado con cédula profesional, con enfoque en tecnologías modernas y mejores prácticas de desarrollo.",
+    "status": { "es": "Titulado", "en": "Graduated" },
+    "description": {
+      "es": "Formación sólida en desarrollo de software, bases de datos, metodologías de desarrollo y fundamentos de la informática. Titulado con cédula profesional, con enfoque en tecnologías modernas y mejores prácticas de desarrollo.",
+      "en": "Solid training in software development, databases, development methodologies and computer science fundamentals. Graduated with professional license, focused on modern technologies and best development practices."
+    },
     "subjects": [
-      {
-        "name": "Desarrollo de Software",
-        "icon": "code"
-      },
-      {
-        "name": "Bases de Datos",
-        "icon": "database"
-      },
-      {
-        "name": "Metodologías Ágiles",
-        "icon": "agile"
-      },
-      {
-        "name": "Arquitectura de Software",
-        "icon": "architecture"
-      },
-      {
-        "name": "Algoritmos y Estructuras",
-        "icon": "algorithm"
-      },
-      {
-        "name": "Redes y Sistemas",
-        "icon": "network"
-      }
+      { "name": { "es": "Desarrollo de Software", "en": "Software Development" }, "icon": "code" },
+      { "name": { "es": "Bases de Datos", "en": "Databases" }, "icon": "database" },
+      { "name": { "es": "Metodologías Ágiles", "en": "Agile Methodologies" }, "icon": "agile" },
+      { "name": { "es": "Arquitectura de Software", "en": "Software Architecture" }, "icon": "architecture" },
+      { "name": { "es": "Algoritmos y Estructuras", "en": "Algorithms and Structures" }, "icon": "algorithm" },
+      { "name": { "es": "Redes y Sistemas", "en": "Networks and Systems" }, "icon": "network" }
     ]
   },
   "certifications": [
     {
       "id": 1,
-      "title": "Curso de Introducción a la Automatización de Pruebas",
+      "title": { "es": "Curso de Introducción a la Automatización de Pruebas", "en": "Introduction to Test Automation Course" },
       "provider": "Platzi",
       "icon": "testing",
-      "description": "Fundamentos de testing automatizado, herramientas y mejores prácticas para asegurar la calidad del software."
+      "description": {
+        "es": "Fundamentos de testing automatizado, herramientas y mejores prácticas para asegurar la calidad del software.",
+        "en": "Fundamentals of automated testing, tools and best practices to ensure software quality."
+      }
     },
     {
       "id": 2,
-      "title": "Curso de Terminal y Línea de Comandos",
+      "title": { "es": "Curso de Terminal y Línea de Comandos", "en": "Terminal and Command Line Course" },
       "provider": "Platzi",
       "icon": "terminal",
-      "description": "Dominio de la terminal, comandos esenciales y automatización de tareas para mejorar la productividad."
+      "description": {
+        "es": "Dominio de la terminal, comandos esenciales y automatización de tareas para mejorar la productividad.",
+        "en": "Mastery of the terminal, essential commands and task automation to improve productivity."
+      }
     },
     {
       "id": 3,
-      "title": "Backend con Node.js: API REST con Express.js",
+      "title": { "es": "Backend con Node.js: API REST con Express.js", "en": "Backend with Node.js: REST API with Express.js" },
       "provider": "Platzi",
       "icon": "nodejs",
-      "description": "Desarrollo de APIs RESTful con Node.js y Express, incluyendo autenticación, validación y mejores prácticas."
+      "description": {
+        "es": "Desarrollo de APIs RESTful con Node.js y Express, incluyendo autenticación, validación y mejores prácticas.",
+        "en": "Development of RESTful APIs with Node.js and Express, including authentication, validation and best practices."
+      }
     },
     {
       "id": 4,
-      "title": "Curso Profesional de JavaScript",
+      "title": { "es": "Curso Profesional de JavaScript", "en": "Professional JavaScript Course" },
       "provider": "Platzi",
       "icon": "javascript",
-      "description": "JavaScript avanzado, ES6+, programación funcional, asíncrona y patrones de diseño modernos."
+      "description": {
+        "es": "JavaScript avanzado, ES6+, programación funcional, asíncrona y patrones de diseño modernos.",
+        "en": "Advanced JavaScript, ES6+, functional programming, asynchronous programming and modern design patterns."
+      }
     },
     {
       "id": 5,
-      "title": "Configuración de Entorno en Linux",
+      "title": { "es": "Configuración de Entorno en Linux", "en": "Environment Configuration in Linux" },
       "provider": "Platzi",
       "icon": "linux",
-      "description": "Configuración y optimización de entornos de desarrollo en sistemas Linux para máxima productividad."
+      "description": {
+        "es": "Configuración y optimización de entornos de desarrollo en sistemas Linux para máxima productividad.",
+        "en": "Configuration and optimization of development environments in Linux systems for maximum productivity."
+      }
     },
     {
       "id": 6,
-      "title": "JavaScript Engine (V8) y el Navegador",
+      "title": { "es": "JavaScript Engine (V8) y el Navegador", "en": "JavaScript Engine (V8) and the Browser" },
       "provider": "Platzi",
       "icon": "browser",
-      "description": "Funcionamiento interno del motor V8, optimización de código y comprensión profunda del runtime de JavaScript."
+      "description": {
+        "es": "Funcionamiento interno del motor V8, optimización de código y comprensión profunda del runtime de JavaScript.",
+        "en": "Internal workings of the V8 engine, code optimization and deep understanding of the JavaScript runtime."
+      }
     },
     {
       "id": 7,
-      "title": "Curso Práctico de Frontend Developer",
+      "title": { "es": "Curso Práctico de Frontend Developer", "en": "Practical Frontend Developer Course" },
       "provider": "Platzi",
       "icon": "frontend",
-      "description": "Desarrollo frontend moderno, HTML5, CSS3, JavaScript, responsive design y mejores prácticas de UI/UX."
+      "description": {
+        "es": "Desarrollo frontend moderno, HTML5, CSS3, JavaScript, responsive design y mejores prácticas de UI/UX.",
+        "en": "Modern frontend development, HTML5, CSS3, JavaScript, responsive design and UI/UX best practices."
+      }
     }
   ],
   "philosophy": [
     {
-      "title": "Aprendizaje Continuo",
+      "title": { "es": "Aprendizaje Continuo", "en": "Continuous Learning" },
       "icon": "learning",
-      "description": "Mantengo una mentalidad de crecimiento constante, siempre buscando nuevas tecnologías y metodologías para mejorar mis habilidades profesionales."
+      "description": {
+        "es": "Mantengo una mentalidad de crecimiento constante, siempre buscando nuevas tecnologías y metodologías para mejorar mis habilidades profesionales.",
+        "en": "I maintain a constant growth mindset, always seeking new technologies and methodologies to improve my professional skills."
+      }
     },
     {
-      "title": "Aprendizaje Práctico",
+      "title": { "es": "Aprendizaje Práctico", "en": "Practical Learning" },
       "icon": "practice",
-      "description": "Prefiero el aprendizaje hands-on, aplicando inmediatamente los conocimientos adquiridos en proyectos reales para consolidar el aprendizaje."
+      "description": {
+        "es": "Prefiero el aprendizaje hands-on, aplicando inmediatamente los conocimientos adquiridos en proyectos reales para consolidar el aprendizaje.",
+        "en": "I prefer hands-on learning, immediately applying acquired knowledge in real projects to consolidate learning."
+      }
     },
     {
-      "title": "Compartir Conocimiento",
+      "title": { "es": "Compartir Conocimiento", "en": "Sharing Knowledge" },
       "icon": "share",
-      "description": "Creo en el poder de compartir conocimiento con la comunidad, participando activamente en foros y ayudando a otros desarrolladores."
+      "description": {
+        "es": "Creo en el poder de compartir conocimiento con la comunidad, participando activamente en foros y ayudando a otros desarrolladores.",
+        "en": "I believe in the power of sharing knowledge with the community, actively participating in forums and helping other developers."
+      }
     }
   ],
   "goals": [
     {
       "id": 1,
-      "title": "Inglés Técnico Avanzado",
-      "period": "Corto Plazo (6 meses)",
-      "description": "Fortalecer mi inglés técnico para comunicación efectiva en equipos internacionales y acceso a documentación técnica avanzada."
+      "title": { "es": "Inglés Técnico Avanzado", "en": "Advanced Technical English" },
+      "period": { "es": "Corto Plazo (6 meses)", "en": "Short Term (6 months)" },
+      "description": {
+        "es": "Fortalecer mi inglés técnico para comunicación efectiva en equipos internacionales y acceso a documentación técnica avanzada.",
+        "en": "Strengthen my technical English for effective communication in international teams and access to advanced technical documentation."
+      }
     },
     {
       "id": 2,
-      "title": "Inteligencia Artificial y Machine Learning",
-      "period": "Mediano Plazo (1 año)",
-      "description": "Explorar tecnologías emergentes de IA para crear asistentes inteligentes y mejorar la experiencia del usuario en aplicaciones web."
+      "title": { "es": "Inteligencia Artificial y Machine Learning", "en": "Artificial Intelligence and Machine Learning" },
+      "period": { "es": "Mediano Plazo (1 año)", "en": "Mid Term (1 year)" },
+      "description": {
+        "es": "Explorar tecnologías emergentes de IA para crear asistentes inteligentes y mejorar la experiencia del usuario en aplicaciones web.",
+        "en": "Explore emerging AI technologies to create intelligent assistants and improve user experience in web applications."
+      }
     },
     {
       "id": 3,
-      "title": "Microservicios y Arquitectura Backend",
-      "period": "Largo Plazo (2 años)",
-      "description": "Especializarme en arquitectura de microservicios, contenedores y tecnologías cloud para desarrollo backend escalable."
+      "title": { "es": "Microservicios y Arquitectura Backend", "en": "Microservices and Backend Architecture" },
+      "period": { "es": "Largo Plazo (2 años)", "en": "Long Term (2 years)" },
+      "description": {
+        "es": "Especializarme en arquitectura de microservicios, contenedores y tecnologías cloud para desarrollo backend escalable.",
+        "en": "Specialize in microservices architecture, containers and cloud technologies for scalable backend development."
+      }
     }
   ]
 }

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -2,22 +2,25 @@
   "jobs": [
     {
       "id": 1,
-      "title": "Front-End Developer",
+      "title": { "es": "Front-End Developer", "en": "Front-End Developer" },
       "company": "Sye Software (SAT)",
-      "period": "Junio 2024 - Presente",
-      "duration": "Trabajo Actual",
+      "period": { "es": "Junio 2024 - Presente", "en": "June 2024 - Present" },
+      "duration": { "es": "Trabajo Actual", "en": "Current Job" },
       "type": "current",
-      "description": "Responsable único del Front-End del módulo de Consultas en el sistema SICOJ del SAT, compuesto por más de 7 módulos jurídicos.",
+      "description": {
+        "es": "Responsable único del Front-End del módulo de Consultas en el sistema SICOJ del SAT, compuesto por más de 7 módulos jurídicos.",
+        "en": "Sole Front-End responsible for the Consultations module in the SAT's SICOJ system, composed of more than 7 legal modules."
+      },
       "achievements": [
-        "Desarrollé componentes reutilizables en Svelte con TypeScript",
-        "Integré servicios RESTful desde .NET 6 MVC",
-        "Implementé gestión de estado con Redux",
-        "Reconocido por entregar el módulo más avanzado entre todos",
-        "Mantuve el ritmo del proyecto sin apoyo directo"
+        { "es": "Desarrollé componentes reutilizables en Svelte con TypeScript", "en": "Developed reusable Svelte components with TypeScript" },
+        { "es": "Integré servicios RESTful desde .NET 6 MVC", "en": "Integrated RESTful services from .NET 6 MVC" },
+        { "es": "Implementé gestión de estado con Redux", "en": "Implemented state management with Redux" },
+        { "es": "Reconocido por entregar el módulo más avanzado entre todos", "en": "Recognized for delivering the most advanced module of all" },
+        { "es": "Mantuve el ritmo del proyecto sin apoyo directo", "en": "Maintained project pace without direct support" }
       ],
       "technologies": [
         "Svelte",
-        "TypeScript", 
+        "TypeScript",
         "Redux",
         ".NET 6 MVC",
         "GitLab",
@@ -28,18 +31,21 @@
     },
     {
       "id": 2,
-      "title": "Full Stack Developer",
+      "title": { "es": "Full Stack Developer", "en": "Full Stack Developer" },
       "company": "Towa Software",
-      "period": "Mayo 2022 - Mayo 2024",
-      "duration": "2 años",
+      "period": { "es": "Mayo 2022 - Mayo 2024", "en": "May 2022 - May 2024" },
+      "duration": { "es": "2 años", "en": "2 years" },
       "type": "previous",
-      "description": "Desarrollo para el cliente MI4P (EE.UU. y Canadá), enfocado en soluciones para empresas de impresión.",
+      "description": {
+        "es": "Desarrollo para el cliente MI4P (EE.UU. y Canadá), enfocado en soluciones para empresas de impresión.",
+        "en": "Development for client MI4P (USA and Canada), focused on solutions for printing companies."
+      },
       "achievements": [
-        "Construcción de interfaces reactivas en Razor con inyección de Vue.js",
-        "Pruebas automatizadas con Selenium",
-        "Apoyo ocasional al backend corrigiendo bugs en .NET 6",
-        "Manipulación de datos en SQL Server",
-        "Participación en desarrollo del sistema de cobranza ShoppingCart usando Vue puro"
+        { "es": "Construcción de interfaces reactivas en Razor con inyección de Vue.js", "en": "Built reactive interfaces in Razor with Vue.js injection" },
+        { "es": "Pruebas automatizadas con Selenium", "en": "Automated tests with Selenium" },
+        { "es": "Apoyo ocasional al backend corrigiendo bugs en .NET 6", "en": "Occasional backend support fixing bugs in .NET 6" },
+        { "es": "Manipulación de datos en SQL Server", "en": "Data manipulation in SQL Server" },
+        { "es": "Participación en desarrollo del sistema de cobranza ShoppingCart usando Vue puro", "en": "Participated in developing the ShoppingCart billing system using pure Vue" }
       ],
       "technologies": [
         "Vue.js",
@@ -53,17 +59,20 @@
     },
     {
       "id": 3,
-      "title": "Full Stack Developer (Prácticas)",
+      "title": { "es": "Full Stack Developer (Prácticas)", "en": "Full Stack Developer (Internship)" },
       "company": "StrApps Consulting",
-      "period": "Septiembre 2021 - Enero 2022",
-      "duration": "5 meses",
+      "period": { "es": "Septiembre 2021 - Enero 2022", "en": "September 2021 - January 2022" },
+      "duration": { "es": "5 meses", "en": "5 months" },
       "type": "internship",
-      "description": "Diseño de vistas en .NET 6 MVC, jQuery y Bootstrap para un modelo de crédito de cobranzas.",
+      "description": {
+        "es": "Diseño de vistas en .NET 6 MVC, jQuery y Bootstrap para un modelo de crédito de cobranzas.",
+        "en": "Designed .NET 6 MVC views with jQuery and Bootstrap for a collections credit model."
+      },
       "achievements": [
-        "Diseño de vistas en .NET 6 MVC con jQuery y Bootstrap",
-        "Creación de sitios WordPress",
-        "Control de versiones en GitHub bajo metodología Scrum",
-        "Desarrollo de modelo de crédito de cobranzas"
+        { "es": "Diseño de vistas en .NET 6 MVC con jQuery y Bootstrap", "en": "Designed .NET 6 MVC views with jQuery and Bootstrap" },
+        { "es": "Creación de sitios WordPress", "en": "Created WordPress sites" },
+        { "es": "Control de versiones en GitHub bajo metodología Scrum", "en": "Version control in GitHub under Scrum methodology" },
+        { "es": "Desarrollo de modelo de crédito de cobranzas", "en": "Developed collections credit model" }
       ],
       "technologies": [
         ".NET 6 MVC",

--- a/src/data/personal.json
+++ b/src/data/personal.json
@@ -1,7 +1,7 @@
 {
   "profile": {
     "name": "Albert González",
-    "title": "Front-End Developer",
+    "title": { "es": "Desarrollador Front-End", "en": "Front-End Developer" },
     "description": {
       "es": "Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos para instituciones públicas y privadas. Dominio en tecnologías modernas como Svelte, Vue.js y TypeScript. Reconocido por la entrega constante de módulos funcionales, colaborativos y escalables.",
       "en": "Front-End Developer with over 3 years of experience building complex enterprise systems for public and private institutions. Specialized in Vue.js, TypeScript and modern technologies."
@@ -11,7 +11,7 @@
   "contact": {
     "email": "albert.gonzalez@email.com",
     "phone": "+52 (555) 123-4567",
-    "location": "Ciudad de México, México",
+    "location": { "es": "Ciudad de México, México", "en": "Mexico City, Mexico" },
     "linkedin": "linkedin.com/in/albertglez97",
     "github": "github.com/albertglez97"
   },
@@ -28,70 +28,34 @@
     },
     "interests": [
       {
-        "title": {
-          "es": "Componentes Reutilizables",
-          "en": "Reusable Components"
-        },
-        "description": {
-          "es": "Diseño de componentes que beneficien múltiples módulos y mejoren la eficiencia del desarrollo.",
-          "en": "Designing components that benefit multiple modules and improve development efficiency."
-        },
+        "title": { "es": "Componentes Reutilizables", "en": "Reusable Components" },
+        "description": { "es": "Diseño de componentes que beneficien múltiples módulos y mejoren la eficiencia del desarrollo.", "en": "Designing components that benefit multiple modules and improve development efficiency." },
         "icon": "components"
       },
       {
-        "title": {
-          "es": "Reuniones con Clientes",
-          "en": "Client Meetings"
-        },
-        "description": {
-          "es": "Participar en reuniones para comprender a fondo el negocio y los procesos de los clientes.",
-          "en": "Participating in meetings to deeply understand business and client processes."
-        },
+        "title": { "es": "Reuniones con Clientes", "en": "Client Meetings" },
+        "description": { "es": "Participar en reuniones para comprender a fondo el negocio y los procesos de los clientes.", "en": "Participating in meetings to deeply understand business and client processes." },
         "icon": "meetings"
       },
       {
-        "title": {
-          "es": "Inteligencia Artificial",
-          "en": "Artificial Intelligence"
-        },
-        "description": {
-          "es": "Explorar herramientas de IA y crear asistentes inteligentes para mejorar la experiencia del usuario.",
-          "en": "Exploring AI tools and creating intelligent assistants to improve user experience."
-        },
+        "title": { "es": "Inteligencia Artificial", "en": "Artificial Intelligence" },
+        "description": { "es": "Explorar herramientas de IA y crear asistentes inteligentes para mejorar la experiencia del usuario.", "en": "Exploring AI tools and creating intelligent assistants to improve user experience." },
         "icon": "ai"
       }
     ]
   },
   "achievements": [
     {
-      "title": {
-        "es": "Reconocimiento por liderar solo el desarrollo del módulo Consultas en el SAT",
-        "en": "Recognition for single-handedly leading the development of the Queries module at SAT"
-      },
-      "description": {
-        "es": "Manteniendo alto rendimiento y entregando el módulo más avanzado del proyecto.",
-        "en": "Maintaining high performance and delivering the most advanced module of the project."
-      }
+      "title": { "es": "Reconocimiento por liderar solo el desarrollo del módulo Consultas en el SAT", "en": "Recognition for single-handedly leading the development of the Queries module at SAT" },
+      "description": { "es": "Manteniendo alto rendimiento y entregando el módulo más avanzado del proyecto.", "en": "Maintaining high performance and delivering the most advanced module of the project." }
     },
     {
-      "title": {
-        "es": "Considerado clave durante recorte de personal",
-        "en": "Considered key during staff reduction"
-      },
-      "description": {
-        "es": "Por desempeño destacado y contribuciones esenciales al equipo.",
-        "en": "Due to outstanding performance and essential contributions to the team."
-      }
+      "title": { "es": "Considerado clave durante recorte de personal", "en": "Considered key during staff reduction" },
+      "description": { "es": "Por desempeño destacado y contribuciones esenciales al equipo.", "en": "Due to outstanding performance and essential contributions to the team." }
     },
     {
-      "title": {
-        "es": "Asignación de tareas adicionales",
-        "en": "Assignment of additional tasks"
-      },
-      "description": {
-        "es": "Por ser resolutivo ante problemas técnicos complejos.",
-        "en": "For being resourceful in solving complex technical problems."
-      }
+      "title": { "es": "Asignación de tareas adicionales", "en": "Assignment of additional tasks" },
+      "description": { "es": "Por ser resolutivo ante problemas técnicos complejos.", "en": "For being resourceful in solving complex technical problems." }
     }
   ]
 }

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -2,15 +2,18 @@
   "featured": [
     {
       "id": 1,
-      "title": "Atotonilco Estudio",
-      "type": "Destacado",
-      "description": "Sitio web profesional creado para promocionar los servicios de un estudio fotográfico. Desarrollado con enfoque en la experiencia visual y diseño responsivo para mostrar el portafolio de manera atractiva.",
+      "title": { "es": "Atotonilco Estudio", "en": "Atotonilco Studio" },
+      "type": { "es": "Destacado", "en": "Featured" },
+      "description": {
+        "es": "Sitio web profesional creado para promocionar los servicios de un estudio fotográfico. Desarrollado con enfoque en la experiencia visual y diseño responsivo para mostrar el portafolio de manera atractiva.",
+        "en": "Professional website created to promote the services of a photo studio. Developed with focus on visual experience and responsive design to showcase the portfolio attractively."
+      },
       "features": [
-        "Diseño responsivo y moderno",
-        "Galería de imágenes optimizada",
-        "Formulario de contacto funcional",
-        "Optimización SEO",
-        "Carga rápida de imágenes"
+        { "es": "Diseño responsivo y moderno", "en": "Responsive and modern design" },
+        { "es": "Galería de imágenes optimizada", "en": "Optimized image gallery" },
+        { "es": "Formulario de contacto funcional", "en": "Functional contact form" },
+        { "es": "Optimización SEO", "en": "SEO optimization" },
+        { "es": "Carga rápida de imágenes", "en": "Fast image loading" }
       ],
       "technologies": [
         "HTML5",
@@ -24,7 +27,7 @@
       "metrics": {
         "responsive": "100%",
         "performance": "A+",
-        "seo": "SEO Optimizado"
+        "seo": { "es": "SEO Optimizado", "en": "SEO Optimized" }
       },
       "image": "/projects/atotonilco.jpg",
       "url": "https://atotonilco-estudio.com",
@@ -32,15 +35,18 @@
     },
     {
       "id": 2,
-      "title": "Carnal MX",
-      "type": "Destacado",
-      "description": "Plataforma web para un proyecto artístico de crónica contemporánea sobre la Ciudad de México. Incluye galería interactiva, blog de contenido y sistema de suscripciones para seguidores del proyecto.",
+      "title": { "es": "Carnal MX", "en": "Carnal MX" },
+      "type": { "es": "Destacado", "en": "Featured" },
+      "description": {
+        "es": "Plataforma web para un proyecto artístico de crónica contemporánea sobre la Ciudad de México. Incluye galería interactiva, blog de contenido y sistema de suscripciones para seguidores del proyecto.",
+        "en": "Web platform for an artistic contemporary chronicle project about Mexico City. Includes interactive gallery, content blog and subscription system for project followers."
+      },
       "features": [
-        "Galería interactiva de contenido",
-        "Sistema de blog integrado",
-        "Suscripciones de usuarios",
-        "Diseño editorial moderno",
-        "Optimización para móviles"
+        { "es": "Galería interactiva de contenido", "en": "Interactive content gallery" },
+        { "es": "Sistema de blog integrado", "en": "Integrated blog system" },
+        { "es": "Suscripciones de usuarios", "en": "User subscriptions" },
+        { "es": "Diseño editorial moderno", "en": "Modern editorial design" },
+        { "es": "Optimización para móviles", "en": "Mobile optimization" }
       ],
       "technologies": [
         "Vue.js",
@@ -54,7 +60,7 @@
       "metrics": {
         "responsive": "100%",
         "performance": "A",
-        "seo": "Optimizado"
+        "seo": { "es": "Optimizado", "en": "Optimized" }
       },
       "image": "/projects/carnal-mx.jpg",
       "url": "https://carnal-mx.com",
@@ -64,15 +70,18 @@
   "other": [
     {
       "id": 3,
-      "title": "Sistema SICOJ - Módulo Consultas",
-      "type": "Profesional",
-      "description": "Módulo de consultas jurídicas para el Sistema Integral de Control de Juicios del SAT. Desarrollo completo del frontend con componentes reutilizables y gestión de estado avanzada.",
+      "title": { "es": "Sistema SICOJ - Módulo Consultas", "en": "SICOJ System - Consultations Module" },
+      "type": { "es": "Profesional", "en": "Professional" },
+      "description": {
+        "es": "Módulo de consultas jurídicas para el Sistema Integral de Control de Juicios del SAT. Desarrollo completo del frontend con componentes reutilizables y gestión de estado avanzada.",
+        "en": "Legal consultation module for the SAT's Comprehensive Control of Trials System. Complete frontend development with reusable components and advanced state management."
+      },
       "features": [
-        "Componentes reutilizables en Svelte",
-        "Gestión de estado con Redux",
-        "Integración con APIs .NET",
-        "Validaciones dinámicas",
-        "Manejo de errores robusto"
+        { "es": "Componentes reutilizables en Svelte", "en": "Reusable components in Svelte" },
+        { "es": "Gestión de estado con Redux", "en": "State management with Redux" },
+        { "es": "Integración con APIs .NET", "en": "Integration with .NET APIs" },
+        { "es": "Validaciones dinámicas", "en": "Dynamic validations" },
+        { "es": "Manejo de errores robusto", "en": "Robust error handling" }
       ],
       "technologies": [
         "Svelte",
@@ -87,15 +96,18 @@
     },
     {
       "id": 4,
-      "title": "ShoppingCart System",
-      "type": "Profesional",
-      "description": "Sistema de cobranza y carrito de compras para empresa de impresión. Desarrollo con Vue.js puro y integración con sistemas de pago.",
+      "title": { "es": "ShoppingCart System", "en": "ShoppingCart System" },
+      "type": { "es": "Profesional", "en": "Professional" },
+      "description": {
+        "es": "Sistema de cobranza y carrito de compras para empresa de impresión. Desarrollo con Vue.js puro y integración con sistemas de pago.",
+        "en": "Billing and shopping cart system for a printing company. Developed with pure Vue.js and integration with payment systems."
+      },
       "features": [
-        "Carrito de compras dinámico",
-        "Integración con pasarelas de pago",
-        "Gestión de inventario",
-        "Panel administrativo",
-        "Reportes de ventas"
+        { "es": "Carrito de compras dinámico", "en": "Dynamic shopping cart" },
+        { "es": "Integración con pasarelas de pago", "en": "Integration with payment gateways" },
+        { "es": "Gestión de inventario", "en": "Inventory management" },
+        { "es": "Panel administrativo", "en": "Admin panel" },
+        { "es": "Reportes de ventas", "en": "Sales reports" }
       ],
       "technologies": [
         "Vue.js",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,7 +20,10 @@
     "description": "Front-End Developer with over 3 years of experience building complex enterprise systems for public and private institutions. Expertise in modern technologies like Svelte, Vue.js and TypeScript. Recognized for consistently delivering functional, collaborative and scalable modules.",
     "goals": {
       "shortTerm": "Short Term: Advance from semi-senior to senior level, strengthen my technical English and add value to impactful projects.",
-      "longTerm": "Long Term: Work abroad, master emerging technologies like artificial intelligence and specialize in backend microservices."
+      "longTerm": "Long Term: Work abroad, master emerging technologies like artificial intelligence and specialize in backend microservices.",
+      "title": "Professional Goals",
+      "shortTitle": "Short Term",
+      "longTitle": "Long Term"
     },
     "journey": {
       "title": "Professional Journey",
@@ -47,6 +50,26 @@
         "role": "Computer Engineering",
         "company": "Tecnológico de Estudios Superiores de Ecatepec",
         "description": "Graduated with professional license. Strong background in software development, databases and development methodologies."
+      }
+    },
+    "interestsTitle": "Interests and Passions",
+    "softSkills": {
+      "title": "Soft Skills",
+      "communication": {
+        "title": "Effective Communication",
+        "description": "Clear when explaining technical solutions to clients and analysts."
+      },
+      "teamwork": {
+        "title": "Teamwork",
+        "description": "Collaborative with multidisciplinary teams and supportive across areas."
+      },
+      "analytical": {
+        "title": "Analytical Thinking",
+        "description": "Practical solution to complex requirements."
+      },
+      "timeManagement": {
+        "title": "Time Management",
+        "description": "Timely completion of deliveries and documentation of progress."
       }
     }
   },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -20,7 +20,10 @@
     "description": "Desarrollador Front-End con más de 3 años de experiencia en la construcción de sistemas empresariales complejos para instituciones públicas y privadas. Dominio en tecnologías modernas como Svelte, Vue.js y TypeScript. Reconocido por la entrega constante de módulos funcionales, colaborativos y escalables.",
     "goals": {
       "shortTerm": "Corto Plazo: Avanzar de nivel semi-senior a senior, fortalecer mi inglés técnico y aportar valor en proyectos con impacto.",
-      "longTerm": "Largo Plazo: Trabajar en el extranjero, dominar tecnologías emergentes como inteligencia artificial y especializarme en microservicios backend."
+      "longTerm": "Largo Plazo: Trabajar en el extranjero, dominar tecnologías emergentes como inteligencia artificial y especializarme en microservicios backend.",
+      "title": "Objetivos Profesionales",
+      "shortTitle": "Corto Plazo",
+      "longTitle": "Largo Plazo"
     },
     "journey": {
       "title": "Mi Trayectoria Profesional",
@@ -47,6 +50,26 @@
         "role": "Ingeniería en Informática",
         "company": "Tecnológico de Estudios Superiores de Ecatepec",
         "description": "Titulado con cédula profesional. Formación sólida en desarrollo de software, bases de datos y metodologías de desarrollo."
+      }
+    },
+    "interestsTitle": "Intereses y Pasiones",
+    "softSkills": {
+      "title": "Habilidades Blandas",
+      "communication": {
+        "title": "Comunicación Efectiva",
+        "description": "Clara al explicar soluciones técnicas a clientes y analistas."
+      },
+      "teamwork": {
+        "title": "Trabajo en Equipo",
+        "description": "Colaborativo con equipos multidisciplinarios y apoyo entre áreas."
+      },
+      "analytical": {
+        "title": "Pensamiento Analítico",
+        "description": "Solución práctica a requerimientos complejos."
+      },
+      "timeManagement": {
+        "title": "Gestión del Tiempo",
+        "description": "Cumplimiento puntual de entregas y documentación de avances."
       }
     }
   },

--- a/src/interfaces/Education.ts
+++ b/src/interfaces/Education.ts
@@ -1,36 +1,38 @@
+import { MultiLanguageText } from './Personal'
+
 export interface Subject {
-  name: string
+  name: MultiLanguageText
   icon: string
 }
 
 export interface AcademicEducation {
-  degree: string
+  degree: MultiLanguageText
   institution: string
   period: string
-  status: string
-  description: string
+  status: MultiLanguageText
+  description: MultiLanguageText
   subjects: Subject[]
 }
 
 export interface Certification {
   id: number
-  title: string
+  title: MultiLanguageText
   provider: string
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface Philosophy {
-  title: string
+  title: MultiLanguageText
   icon: string
-  description: string
+  description: MultiLanguageText
 }
 
 export interface Goal {
   id: number
-  title: string
-  period: string
-  description: string
+  title: MultiLanguageText
+  period: MultiLanguageText
+  description: MultiLanguageText
 }
 
 export interface EducationData {

--- a/src/interfaces/Experience.ts
+++ b/src/interfaces/Experience.ts
@@ -1,12 +1,14 @@
+import { MultiLanguageText } from './Personal'
+
 export interface Job {
   id: number
-  title: string
+  title: MultiLanguageText
   company: string
-  period: string
-  duration: string
+  period: MultiLanguageText
+  duration: MultiLanguageText
   type: 'current' | 'previous' | 'internship'
-  description: string
-  achievements: string[]
+  description: MultiLanguageText
+  achievements: MultiLanguageText[]
   technologies: string[]
   icon: string
 }

--- a/src/interfaces/Personal.ts
+++ b/src/interfaces/Personal.ts
@@ -5,7 +5,7 @@ export interface MultiLanguageText {
 
 export interface Profile {
   name: string
-  title: string
+  title: MultiLanguageText
   description: MultiLanguageText
   image: string
 }
@@ -13,7 +13,7 @@ export interface Profile {
 export interface Contact {
   email: string
   phone: string
-  location: string
+  location: MultiLanguageText
   linkedin: string
   github: string
 }

--- a/src/interfaces/Projects.ts
+++ b/src/interfaces/Projects.ts
@@ -1,15 +1,17 @@
+import { MultiLanguageText } from './Personal'
+
 export interface ProjectMetrics {
   responsive: string
   performance: string
-  seo: string
+  seo: MultiLanguageText
 }
 
 export interface Project {
   id: number
-  title: string
-  type: string
-  description: string
-  features?: string[]
+  title: MultiLanguageText
+  type: MultiLanguageText
+  description: MultiLanguageText
+  features?: MultiLanguageText[]
   technologies: string[]
   metrics?: ProjectMetrics
   image?: string

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -32,8 +32,8 @@
                 />
               </svg>
             </div>
-            <h3>Ubicación</h3>
-            <p>Ciudad de México, México</p>
+            <h3>{{ t.contact.details.location }}</h3>
+            <p>{{ getTranslatedText(personalData.contact.location) }}</p>
           </div>
 
           <div class="info-card animate-fadeInUp">
@@ -66,8 +66,8 @@
                 />
               </svg>
             </div>
-            <h3>Teléfono</h3>
-            <p>+52 (555) 123-4567</p>
+            <h3>{{ t.contact.details.phone }}</h3>
+            <p>{{ personalData.contact.phone }}</p>
           </div>
 
           <div class="info-card animate-fadeInUp">
@@ -83,8 +83,8 @@
                 />
               </svg>
             </div>
-            <h3>LinkedIn</h3>
-            <p>linkedin.com/in/albertglez97</p>
+            <h3>{{ t.contact.details.linkedin }}</h3>
+            <p>{{ personalData.contact.linkedin }}</p>
           </div>
         </div>
       </section>
@@ -137,7 +137,7 @@
 
       <!-- Goals & Objectives -->
       <section class="goals section">
-        <h2 class="section-title">Objetivos Profesionales</h2>
+        <h2 class="section-title">{{ t.about.goals.title }}</h2>
         <div class="goals-grid">
           <div class="goal-card animate-fadeInUp">
             <div class="goal-icon">
@@ -152,8 +152,8 @@
                 />
               </svg>
             </div>
-            <h3>Corto Plazo</h3>
-            <p>{{ t.about.goals.shortTerm }}</p>
+            <h3>{{ t.about.goals.shortTitle }}</h3>
+            <p>{{ getTranslatedText(personalData.about.goals.shortTerm) }}</p>
           </div>
 
           <div class="goal-card animate-fadeInUp">
@@ -169,17 +169,21 @@
                 />
               </svg>
             </div>
-            <h3>Largo Plazo</h3>
-            <p>{{ t.about.goals.longTerm }}</p>
+            <h3>{{ t.about.goals.longTitle }}</h3>
+            <p>{{ getTranslatedText(personalData.about.goals.longTerm) }}</p>
           </div>
         </div>
       </section>
 
       <!-- Interests & Passions -->
       <section class="interests section">
-        <h2 class="section-title">Intereses y Pasiones</h2>
+        <h2 class="section-title">{{ t.about.interestsTitle }}</h2>
         <div class="interests-grid">
-          <div class="interest-card animate-fadeInUp">
+          <div
+            v-for="interest in personalData.about.interests"
+            :key="interest.title.en"
+            class="interest-card animate-fadeInUp"
+          >
             <div class="interest-icon">
               <svg
                 width="40"
@@ -188,62 +192,27 @@
                 fill="currentColor"
               >
                 <path
+                  v-if="interest.icon === 'components'"
                   d="M9.5,3A6.5,6.5 0 0,1 16,9.5C16,11.11 15.41,12.59 14.44,13.73L14.71,14H15.5L20.5,19L19,20.5L14,15.5V14.71L13.73,14.44C12.59,15.41 11.11,16 9.5,16A6.5,6.5 0 0,1 3,9.5A6.5,6.5 0 0,1 9.5,3M9.5,5C7,5 5,7 5,9.5C5,12 7,14 9.5,14C12,14 14,12 14,9.5C14,7 12,5 9.5,5Z"
                 />
-              </svg>
-            </div>
-            <h3>Componentes Reutilizables</h3>
-            <p>
-              Diseño de componentes que beneficien múltiples módulos y mejoren
-              la eficiencia del desarrollo.
-            </p>
-          </div>
-
-          <div class="interest-card animate-fadeInUp">
-            <div class="interest-icon">
-              <svg
-                width="40"
-                height="40"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
                 <path
+                  v-else-if="interest.icon === 'meetings'"
                   d="M12,2A3,3 0 0,1 15,5V11A3,3 0 0,1 12,14A3,3 0 0,1 9,11V5A3,3 0 0,1 12,2M19,11C19,14.53 16.39,17.44 13,17.93V21H11V17.93C7.61,17.44 5,14.53 5,11H7A5,5 0 0,0 12,16A5,5 0 0,0 17,11H19Z"
                 />
-              </svg>
-            </div>
-            <h3>Reuniones con Clientes</h3>
-            <p>
-              Participar en reuniones para comprender a fondo el negocio y los
-              procesos de los clientes.
-            </p>
-          </div>
-
-          <div class="interest-card animate-fadeInUp">
-            <div class="interest-icon">
-              <svg
-                width="40"
-                height="40"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
                 <path
+                  v-else
                   d="M17.5,12A1.5,1.5 0 0,1 16,10.5A1.5,1.5 0 0,1 17.5,9A1.5,1.5 0 0,1 19,10.5A1.5,1.5 0 0,1 17.5,12M14.5,8A1.5,1.5 0 0,1 13,6.5A1.5,1.5 0 0,1 14.5,5A1.5,1.5 0 0,1 16,6.5A1.5,1.5 0 0,1 14.5,8M9.5,8A1.5,1.5 0 0,1 8,6.5A1.5,1.5 0 0,1 9.5,5A1.5,1.5 0 0,1 11,6.5A1.5,1.5 0 0,1 9.5,8M6.5,12A1.5,1.5 0 0,1 5,10.5A1.5,1.5 0 0,1 6.5,9A1.5,1.5 0 0,1 8,10.5A1.5,1.5 0 0,1 6.5,12M12,3A9,9 0 0,0 3,12A9,9 0 0,0 12,21A8.5,8.5 0 0,0 20.5,12.5A8.5,8.5 0 0,0 12,3Z"
                 />
               </svg>
             </div>
-            <h3>Inteligencia Artificial</h3>
-            <p>
-              Explorar herramientas de IA y crear asistentes inteligentes para
-              mejorar la experiencia del usuario.
-            </p>
+            <h3>{{ getTranslatedText(interest.title) }}</h3>
+            <p>{{ getTranslatedText(interest.description) }}</p>
           </div>
         </div>
       </section>
-
       <!-- Soft Skills -->
       <section class="soft-skills section">
-        <h2 class="section-title">Habilidades Blandas</h2>
+        <h2 class="section-title">{{ t.about.softSkills.title }}</h2>
         <div class="skills-grid">
           <div class="skill-item animate-fadeInUp">
             <div class="skill-icon">
@@ -259,10 +228,8 @@
               </svg>
             </div>
             <div class="skill-content">
-              <h3>Comunicación Efectiva</h3>
-              <p>
-                Clara al explicar soluciones técnicas a clientes y analistas.
-              </p>
+              <h3>{{ t.about.softSkills.communication.title }}</h3>
+              <p>{{ t.about.softSkills.communication.description }}</p>
             </div>
           </div>
 
@@ -280,11 +247,8 @@
               </svg>
             </div>
             <div class="skill-content">
-              <h3>Trabajo en Equipo</h3>
-              <p>
-                Colaborativo con equipos multidisciplinarios y apoyo entre
-                áreas.
-              </p>
+              <h3>{{ t.about.softSkills.teamwork.title }}</h3>
+              <p>{{ t.about.softSkills.teamwork.description }}</p>
             </div>
           </div>
 
@@ -302,8 +266,8 @@
               </svg>
             </div>
             <div class="skill-content">
-              <h3>Pensamiento Analítico</h3>
-              <p>Solución práctica a requerimientos complejos.</p>
+              <h3>{{ t.about.softSkills.analytical.title }}</h3>
+              <p>{{ t.about.softSkills.analytical.description }}</p>
             </div>
           </div>
 
@@ -321,10 +285,8 @@
               </svg>
             </div>
             <div class="skill-content">
-              <h3>Gestión del Tiempo</h3>
-              <p>
-                Cumplimiento puntual de entregas y documentación de avances.
-              </p>
+              <h3>{{ t.about.softSkills.timeManagement.title }}</h3>
+              <p>{{ t.about.softSkills.timeManagement.description }}</p>
             </div>
           </div>
         </div>
@@ -335,10 +297,16 @@
 
 <script setup lang="ts">
 import { useMainStore } from "../stores/main";
+import { usePersonalStore } from "../stores/personal";
+import type { PersonalData } from "../interfaces";
 import { storeToRefs } from "pinia";
 
-const store = useMainStore();
-const { t } = storeToRefs(store);
+const mainStore = useMainStore();
+const personalStore = usePersonalStore();
+const { t } = storeToRefs(mainStore);
+const { getTranslatedText } = mainStore;
+const { getPersonal } = storeToRefs(personalStore);
+const personalData: PersonalData = getPersonal.value;
 </script>
 
 <style scoped>

--- a/src/views/Education.vue
+++ b/src/views/Education.vue
@@ -21,11 +21,11 @@
                 </svg>
               </div>
               <div class="degree-details">
-                <h3>{{ educationData.academic.degree }}</h3>
+                <h3>{{ getTranslatedText(educationData.academic.degree) }}</h3>
                 <h4>{{ educationData.academic.institution }}</h4>
                 <div class="degree-meta">
                   <span class="period">{{ educationData.academic.period }}</span>
-                  <span class="status completed">{{ educationData.academic.status }}</span>
+                  <span class="status completed">{{ getTranslatedText(educationData.academic.status) }}</span>
                 </div>
               </div>
             </div>
@@ -37,14 +37,14 @@
           </div>
           
           <div class="card-content">
-            <p class="degree-description">{{ educationData.academic.description }}</p>
+            <p class="degree-description">{{ getTranslatedText(educationData.academic.description) }}</p>
             
             <div class="subjects-covered">
               <h5>{{ t.education.studyAreas }}</h5>
               <div class="subjects-grid">
                 <div 
                   v-for="subject in educationData.academic.subjects" 
-                  :key="subject.name"
+                  :key="subject.name.en"
                   class="subject-item"
                 >
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -55,7 +55,7 @@
                     <path v-else-if="subject.icon === 'algorithm'" d="M12,17.27L18.18,21L16.54,13.97L22,9.24L14.81,8.62L12,2L9.19,8.62L2,9.24L7.46,13.97L5.82,21L12,17.27Z"/>
                     <path v-else d="M19,3A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5A2,2 0 0,1 5,3H19M18.5,18.5V13.2A3.26,3.26 0 0,0 15.24,9.94C14.39,9.94 13.4,10.46 12.92,11.24V10.13H10.13V18.5H12.92V13.57C12.92,12.8 13.54,12.17 14.31,12.17A1.4,1.4 0 0,1 15.71,13.57V18.5H18.5M6.88,8.56A1.68,1.68 0 0,0 8.56,6.88C8.56,5.95 7.81,5.19 6.88,5.19A1.69,1.69 0 0,0 5.19,6.88C5.19,7.81 5.95,8.56 6.88,8.56M8.27,18.5V10.13H5.5V18.5H8.27Z"/>
                   </svg>
-                  <span>{{ subject.name }}</span>
+                  <span>{{ getTranslatedText(subject.name) }}</span>
                 </div>
               </div>
             </div>
@@ -83,7 +83,7 @@
           <div class="philosophy-grid">
             <div 
               v-for="philosophy in educationData.philosophy" 
-              :key="philosophy.title"
+              :key="philosophy.title.en"
               class="philosophy-card animate-fadeInUp"
             >
               <div class="philosophy-icon">
@@ -93,8 +93,8 @@
                   <path v-else d="M16,4C18.11,4 20.11,4.89 21.61,6.39C23.11,7.89 24,9.89 24,12A8,8 0 0,1 16,20H5A5,5 0 0,1 0,15A5,5 0 0,1 5,10C5.59,10 6.16,10.13 6.69,10.36C7.61,7.24 10.57,5 14,5C14.68,5 15.34,5.11 16,5.28V4Z"/>
                 </svg>
               </div>
-              <h3>{{ philosophy.title }}</h3>
-              <p>{{ philosophy.description }}</p>
+              <h3>{{ getTranslatedText(philosophy.title) }}</h3>
+              <p>{{ getTranslatedText(philosophy.description) }}</p>
             </div>
           </div>
         </div>
@@ -115,10 +115,10 @@
                 <span class="goal-number">{{ goal.id }}</span>
               </div>
               <div class="goal-content">
-                <h3>{{ goal.title }}</h3>
-                <p>{{ goal.description }}</p>
+                <h3>{{ getTranslatedText(goal.title) }}</h3>
+                <p>{{ getTranslatedText(goal.description) }}</p>
                 <div class="goal-timeline-info">
-                  <span class="goal-period">{{ goal.period }}</span>
+                  <span class="goal-period">{{ getTranslatedText(goal.period) }}</span>
                 </div>
               </div>
             </div>
@@ -139,6 +139,7 @@ import type { EducationData } from '../interfaces'
 const mainStore = useMainStore()
 const educationStore = useEducationStore()
 const { t } = storeToRefs(mainStore)
+const { getTranslatedText } = mainStore
 const { getEducation } = storeToRefs(educationStore)
 const educationData: EducationData = getEducation.value
 </script>


### PR DESCRIPTION
## Summary
- add bilingual fields to project, experience, education and personal datasets
- update cards and views to read localized text with getTranslatedText
- extend translations with goals, interests and soft skills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689698a02d0c832dacb55f88e36bc0aa