### PR TITLE
refactor: aplicar arquitectura hexagonal a datos personales

### DIFF
--- a/src/application/personal/GetPersonalUseCase.ts
+++ b/src/application/personal/GetPersonalUseCase.ts
@@ -1,0 +1,13 @@
+// Caso de uso para obtener la información personal
+// Se comunica con un repositorio que implementa el puerto del dominio
+import type { PersonalData } from '../../domain/personal/Personal'
+import type { PersonalRepository } from '../../domain/personal/PersonalRepository'
+
+export class GetPersonalUseCase {
+  constructor(private repository: PersonalRepository) {}
+
+  // Ejecuta la lógica de aplicación para recuperar los datos personales
+  execute(): PersonalData {
+    return this.repository.getPersonal()
+  }
+}

--- a/src/domain/personal/Personal.ts
+++ b/src/domain/personal/Personal.ts
@@ -1,8 +1,10 @@
+// Texto que puede representarse en español e inglés
 export interface MultiLanguageText {
   es: string
   en: string
 }
 
+// Datos principales del perfil
 export interface Profile {
   name: string
   title: MultiLanguageText
@@ -10,6 +12,7 @@ export interface Profile {
   image: string
 }
 
+// Información de contacto personal
 export interface Contact {
   email: string
   phone: string
@@ -18,27 +21,32 @@ export interface Contact {
   github: string
 }
 
+// Objetivos profesionales a corto y largo plazo
 export interface Goals {
   shortTerm: MultiLanguageText
   longTerm: MultiLanguageText
 }
 
+// Interés personal o profesional
 export interface Interest {
   title: MultiLanguageText
   description: MultiLanguageText
   icon: string
 }
 
+// Información adicional sobre la persona
 export interface About {
   goals: Goals
   interests: Interest[]
 }
 
+// Logros destacados de la trayectoria
 export interface Achievement {
   title: MultiLanguageText
   description: MultiLanguageText
 }
 
+// Conjunto de datos personales completos
 export interface PersonalData {
   profile: Profile
   contact: Contact

--- a/src/domain/personal/PersonalRepository.ts
+++ b/src/domain/personal/PersonalRepository.ts
@@ -1,0 +1,8 @@
+// Puerto del dominio para obtener datos personales
+// Define las operaciones que cualquier repositorio de datos personales debe implementar
+import type { PersonalData } from './Personal'
+
+export interface PersonalRepository {
+  // Devuelve la información personal completa
+  getPersonal(): PersonalData
+}

--- a/src/infrastructure/personal/StaticPersonalRepository.ts
+++ b/src/infrastructure/personal/StaticPersonalRepository.ts
@@ -1,0 +1,11 @@
+// Implementación del repositorio que obtiene los datos desde un archivo estático
+import type { PersonalData } from '../../domain/personal/Personal'
+import type { PersonalRepository } from '../../domain/personal/PersonalRepository'
+import personalData from '../../data/personal.json'
+
+export class StaticPersonalRepository implements PersonalRepository {
+  // Retorna los datos cargados desde el archivo JSON
+  getPersonal(): PersonalData {
+    return personalData
+  }
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -36,14 +36,3 @@ export type {
   TechnologyBubble
 } from './Projects'
 
-// Personal interfaces
-export type {
-  MultiLanguageText,
-  Profile,
-  Contact,
-  Goals,
-  Interest,
-  About,
-  Achievement,
-  PersonalData
-} from './Personal'

--- a/src/stores/personal.ts
+++ b/src/stores/personal.ts
@@ -1,28 +1,33 @@
 import { defineStore } from 'pinia'
 import { computed } from 'vue'
-import type { PersonalData } from '../interfaces'
-import personalData from '../data/personal.json'
+import type { PersonalData } from '../domain/personal/Personal'
+import { GetPersonalUseCase } from '../application/personal/GetPersonalUseCase'
+import { StaticPersonalRepository } from '../infrastructure/personal/StaticPersonalRepository'
 
 export const usePersonalStore = defineStore('personal', () => {
-  // State
-  const personal: PersonalData = personalData
+  // Instanciamos el repositorio y el caso de uso (capa de infraestructura -> aplicación)
+  const repository = new StaticPersonalRepository()
+  const getPersonalUseCase = new GetPersonalUseCase(repository)
 
-  // Getters
+  // Estado: datos personales obtenidos a través del caso de uso
+  const personal: PersonalData = getPersonalUseCase.execute()
+
+  // Getters: exponen la información al exterior
   const getPersonal = computed(() => personal)
-  
+
   const getProfile = computed(() => personal.profile)
-  
+
   const getContact = computed(() => personal.contact)
-  
+
   const getAbout = computed(() => personal.about)
-  
+
   const getAchievements = computed(() => personal.achievements)
 
   const getGoals = computed(() => personal.about.goals)
-  
+
   const getInterests = computed(() => personal.about.interests)
 
-  // Actions
+  // Actions: métodos que procesan o filtran la información
   const getContactInfo = () => {
     return {
       email: personal.contact.email,
@@ -42,9 +47,9 @@ export const usePersonalStore = defineStore('personal', () => {
   }
 
   return {
-    // State
+    // Estado
     personal,
-    
+
     // Getters
     getPersonal,
     getProfile,
@@ -53,8 +58,8 @@ export const usePersonalStore = defineStore('personal', () => {
     getAchievements,
     getGoals,
     getInterests,
-    
-    // Actions
+
+    // Acciones
     getContactInfo,
     getProfileDescription,
     getGoalsByPeriod

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -298,7 +298,8 @@
 <script setup lang="ts">
 import { useMainStore } from "../stores/main";
 import { usePersonalStore } from "../stores/personal";
-import type { PersonalData } from "../interfaces";
+// Importamos el modelo del dominio
+import type { PersonalData } from "../domain/personal/Personal";
 import { storeToRefs } from "pinia";
 
 const mainStore = useMainStore();


### PR DESCRIPTION
## Summary
- estructura de dominio para datos personales
- caso de uso y repositorio estático
- store adaptada a la nueva arquitectura

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68975a06d030832dad53cc3d382ca8e3