### PR TITLE
feat: add formspree contact service

### DIFF
--- a/src/api/contact.ts
+++ b/src/api/contact.ts
@@ -1,0 +1,28 @@
+import axiosInstance from '../lib/axios'
+
+// Interface describing the expected fields for the contact form
+export interface ContactFormData {
+  name: string
+  email: string
+  subject: string
+  message: string
+}
+
+/**
+ * Sends the contact form data to Formspree.
+ * @param data Object containing the user's contact information
+ * @returns The response data from Formspree
+ * @throws Error when the request fails or a non-200 status is returned
+ */
+export const sendContactForm = async (data: ContactFormData) => {
+  try {
+    const response = await axiosInstance.post('', data)
+    if (response.status !== 200) {
+      throw new Error('Unexpected response status')
+    }
+    return response.data
+  } catch (error: any) {
+    // Provide a readable error message for the calling component
+    throw new Error(error?.response?.data?.message || 'Failed to send message')
+  }
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,17 @@
+import axios from 'axios'
+
+/**
+ * Axios instance configured for Formspree requests.
+ * Setting the baseURL allows us to make requests without
+ * repeating the endpoint path in each service call.
+ */
+const axiosInstance = axios.create({
+  baseURL: 'https://formspree.io/f/xblajzlk',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  }
+})
+
+export default axiosInstance
+export { axiosInstance }


### PR DESCRIPTION
## Summary
- configure Axios instance for Formspree
- add contact form API service
- wire contact view to send form via Formspree with loading and feedback states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf026ac44832da456d378331d4e8d