### PR TITLE
Add interactive 3D TechGalaxy visualization with fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "portafolio",
       "version": "1.0.0",
       "dependencies": {
+        "@types/three": "^0.179.0",
         "axios": "^1.11.0",
         "pinia": "^2.1.0",
+        "three": "^0.179.1",
         "vue": "^3.4.0",
         "vue-i18n": "^11.1.11",
         "vue-router": "^4.2.0"
@@ -199,6 +201,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -957,6 +965,12 @@
         "win32"
       ]
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -990,6 +1004,33 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.179.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.179.0.tgz",
+      "integrity": "sha512-VgbFG2Pgsm84BqdegZzr7w2aKbQxmgzIu4Dy7/75ygiD/0P68LKmp5ie08KMPNqGTQwIge8s6D1guZf1RnZE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
@@ -1303,6 +1344,12 @@
         "js-beautify": "^1.14.9",
         "vue-component-type-helpers": "^2.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
       "version": "2.0.0",
@@ -1824,6 +1871,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -2231,6 +2284,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -2784,6 +2843,12 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/three": {
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
       "license": "MIT"
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@types/three": "^0.179.0",
     "axios": "^1.11.0",
     "pinia": "^2.1.0",
+    "three": "^0.179.1",
     "vue": "^3.4.0",
     "vue-i18n": "^11.1.11",
     "vue-router": "^4.2.0"

--- a/src/components/TechGalaxy.vue
+++ b/src/components/TechGalaxy.vue
@@ -1,0 +1,280 @@
+<template>
+  <div
+    ref="container"
+    class="tech-galaxy"
+    :style="{ width: resolvedWidth, height: resolvedHeight }"
+  >
+    <canvas
+      v-if="show3D"
+      ref="canvas"
+      role="img"
+      aria-label="Visualización 3D de tecnologías"
+    ></canvas>
+    <div v-else class="tech-fallback">
+      <TechBadge
+        v-for="tech in technologies"
+        :key="tech"
+        :label="tech"
+        size="sm"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  AmbientLight,
+  BufferGeometry,
+  DirectionalLight,
+  Float32BufferAttribute,
+  PerspectiveCamera,
+  Points,
+  PointsMaterial,
+  Raycaster,
+  Scene,
+  Sprite,
+  Vector2,
+  WebGLRenderer
+} from 'three'
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
+import TechBadge from './TechBadge.vue'
+import { createTextSprite } from '../lib/createTextSprite'
+
+interface Props {
+  technologies: string[]
+  width?: number | string
+  height?: number | string
+  autoRotate?: boolean
+  autoRotateSpeed?: number
+  radius?: number
+  enableDamping?: boolean
+  dampingFactor?: number
+  particleDensity?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  width: '100%',
+  height: 480,
+  autoRotate: true,
+  autoRotateSpeed: 1,
+  radius: 10,
+  enableDamping: true,
+  dampingFactor: 0.05,
+  particleDensity: 500
+})
+
+const emit = defineEmits<{ (e: 'select', tech: string): void }>()
+
+const container = ref<HTMLDivElement | null>(null)
+const canvas = ref<HTMLCanvasElement | null>(null)
+const show3D = ref(true)
+
+let renderer: WebGLRenderer
+let scene: Scene
+let camera: PerspectiveCamera
+let controls: OrbitControls
+let animationId = 0
+const sprites: Sprite[] = []
+const raycaster = new Raycaster()
+const mouse = new Vector2()
+let hovered: Sprite | null = null
+
+const resolvedWidth = computed(() =>
+  typeof props.width === 'number' ? `${props.width}px` : props.width
+)
+const resolvedHeight = computed(() =>
+  typeof props.height === 'number' ? `${props.height}px` : props.height
+)
+
+function isWebGLAvailable(): boolean {
+  try {
+    const canvas = document.createElement('canvas')
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+    )
+  } catch (e) {
+    return false
+  }
+}
+
+const prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches
+
+onMounted(() => {
+  if (!isWebGLAvailable() || prefersReducedMotion) {
+    show3D.value = false
+    return
+  }
+  init()
+  animate()
+  window.addEventListener('resize', onResize)
+  container.value?.addEventListener('pointermove', onPointerMove)
+  container.value?.addEventListener('click', onClick)
+})
+
+onBeforeUnmount(() => {
+  if (!show3D.value) return
+  cancelAnimationFrame(animationId)
+  controls.dispose()
+  renderer.dispose()
+  scene.traverse(obj => {
+    const anyObj = obj as any
+    if (anyObj.geometry) anyObj.geometry.dispose()
+    if (anyObj.material) {
+      if (Array.isArray(anyObj.material)) {
+        anyObj.material.forEach((m: any) => m.dispose())
+      } else {
+        anyObj.material.dispose()
+      }
+    }
+  })
+  window.removeEventListener('resize', onResize)
+  container.value?.removeEventListener('pointermove', onPointerMove)
+  container.value?.removeEventListener('click', onClick)
+})
+
+function init() {
+  renderer = new WebGLRenderer({
+    canvas: canvas.value!,
+    antialias: true,
+    alpha: true
+  })
+  renderer.setPixelRatio(window.devicePixelRatio)
+  renderer.setSize(container.value!.clientWidth, container.value!.clientHeight)
+
+  scene = new Scene()
+  camera = new PerspectiveCamera(
+    50,
+    container.value!.clientWidth / container.value!.clientHeight,
+    0.1,
+    1000
+  )
+  camera.position.set(0, 0, props.radius * 3)
+
+  controls = new OrbitControls(camera, renderer.domElement)
+  controls.enableDamping = props.enableDamping
+  controls.dampingFactor = props.dampingFactor
+  controls.autoRotate = props.autoRotate
+  controls.autoRotateSpeed = props.autoRotateSpeed
+  controls.minDistance = props.radius * 1.2
+  controls.maxDistance = props.radius * 4
+
+  const ambient = new AmbientLight(0xffffff, 0.6)
+  const directional = new DirectionalLight(0xffffff, 0.5)
+  directional.position.set(1, 1, 1)
+  scene.add(ambient, directional)
+
+  // Star field
+  const starGeometry = new BufferGeometry()
+  const positions: number[] = []
+  const distance = props.radius * 5
+  for (let i = 0; i < props.particleDensity; i++) {
+    positions.push(
+      (Math.random() - 0.5) * distance * 2,
+      (Math.random() - 0.5) * distance * 2,
+      (Math.random() - 0.5) * distance * 2
+    )
+  }
+  starGeometry.setAttribute('position', new Float32BufferAttribute(positions, 3))
+  const starMaterial = new PointsMaterial({
+    color: 0xffffff,
+    size: 0.05,
+    transparent: true,
+    opacity: 0.5
+  })
+  const stars = new Points(starGeometry, starMaterial)
+  scene.add(stars)
+
+  // Technology sprites on a sphere
+  const N = props.technologies.length
+  const radius = props.radius
+  for (let i = 0; i < N; i++) {
+    const tech = props.technologies[i]
+    const phi = Math.acos(1 - (2 * (i + 0.5)) / N)
+    const theta = Math.PI * (1 + Math.sqrt(5)) * (i + 0.5)
+    const x = radius * Math.cos(theta) * Math.sin(phi)
+    const y = radius * Math.sin(theta) * Math.sin(phi)
+    const z = radius * Math.cos(phi)
+    const sprite = createTextSprite(tech)
+    sprite.position.set(x, y, z)
+    sprites.push(sprite)
+    scene.add(sprite)
+  }
+}
+
+function animate() {
+  animationId = requestAnimationFrame(animate)
+  sprites.forEach(sprite => {
+    const dist = camera.position.distanceTo(sprite.position)
+    const min = props.radius * 0.8
+    const max = props.radius * 3
+    const ratio = Math.min(Math.max((dist - min) / (max - min), 0), 1)
+    const scale = 1.5 - ratio
+    sprite.scale.setScalar(scale)
+    const material = sprite.material as any
+    material.opacity = 1 - ratio * 0.5
+  })
+  controls.update()
+  renderer.render(scene, camera)
+}
+
+function onResize() {
+  if (!container.value) return
+  const w = container.value.clientWidth
+  const h = container.value.clientHeight
+  renderer.setSize(w, h)
+  camera.aspect = w / h
+  camera.updateProjectionMatrix()
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (!canvas.value) return
+  const rect = canvas.value.getBoundingClientRect()
+  mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1
+  mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1
+  raycaster.setFromCamera(mouse, camera)
+  const intersects = raycaster.intersectObjects(sprites)
+  if (intersects.length > 0) {
+    const sprite = intersects[0].object as Sprite
+    if (hovered !== sprite) {
+      if (hovered) hovered.scale.divideScalar(1.2)
+      hovered = sprite
+      hovered.scale.multiplyScalar(1.2)
+      if (canvas.value) canvas.value.title = sprite.userData.text || ''
+    }
+  } else if (hovered) {
+    hovered.scale.divideScalar(1.2)
+    hovered = null
+    if (canvas.value) canvas.value.title = ''
+  }
+}
+
+function onClick() {
+  if (hovered) {
+    controls.target.copy(hovered.position)
+    emit('select', hovered.userData.text)
+  }
+}
+</script>
+
+<style scoped>
+.tech-galaxy {
+  position: relative;
+}
+
+.tech-fallback {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  justify-content: center;
+}
+
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+</style>

--- a/src/lib/createTextSprite.ts
+++ b/src/lib/createTextSprite.ts
@@ -1,0 +1,54 @@
+import { CanvasTexture, Sprite, SpriteMaterial } from 'three'
+
+/**
+ * Creates a Three.js Sprite containing the given text rendered on a canvas.
+ * The sprite uses theme colors for contrast and a subtle background/border
+ * to maintain legibility.
+ */
+export function createTextSprite(text: string): Sprite {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')!
+
+  const padding = 16
+  const maxWidth = 512
+  const rootStyles = getComputedStyle(document.documentElement)
+  const fontFamily = rootStyles.getPropertyValue('--font-family').trim() ||
+    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+  let fontSize = 48
+
+  ctx.font = `${fontSize}px ${fontFamily}`
+  let textWidth = ctx.measureText(text).width
+
+  if (textWidth + padding * 2 > maxWidth) {
+    const scale = (maxWidth - padding * 2) / textWidth
+    fontSize = Math.floor(fontSize * scale)
+    ctx.font = `${fontSize}px ${fontFamily}`
+    textWidth = ctx.measureText(text).width
+  }
+
+  canvas.width = textWidth + padding * 2
+  canvas.height = fontSize + padding * 2
+
+  ctx.font = `${fontSize}px ${fontFamily}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+
+  const textColor = rootStyles.getPropertyValue('--text-primary').trim() || '#fff'
+  const backgroundColor = 'rgba(0,0,0,0.4)'
+  const borderColor = 'rgba(255,255,255,0.3)'
+
+  ctx.fillStyle = backgroundColor
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  ctx.strokeStyle = borderColor
+  ctx.lineWidth = 1
+  ctx.strokeRect(0.5, 0.5, canvas.width - 1, canvas.height - 1)
+  ctx.fillStyle = textColor
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2)
+
+  const texture = new CanvasTexture(canvas)
+  const material = new SpriteMaterial({ map: texture, transparent: true })
+  const sprite = new Sprite(material)
+  sprite.scale.set(canvas.width / 100, canvas.height / 100, 1)
+  sprite.userData.text = text
+  return sprite
+}

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -87,14 +87,7 @@
       <section class="technologies-section section">
         <div class="tech-content">
           <h2 class="section-title">{{ t.projects.techSection }}</h2>
-          <div class="tech-cloud">
-            <TechBadge
-              v-for="tech in allTechnologies"
-              :key="tech.name"
-              :label="tech.name"
-              size="sm"
-            />
-          </div>
+          <TechGalaxy :technologies="technologyNames" />
         </div>
       </section>
     </div>
@@ -102,11 +95,12 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useMainStore } from '../stores/main'
 import { useProjectsStore } from '../stores/projects'
 import ProjectCard from '../components/ProjectCard.vue'
-import TechBadge from '../components/TechBadge.vue'
+import TechGalaxy from '../components/TechGalaxy.vue'
 import type { ProjectsData } from '../interfaces'
 
 const mainStore = useMainStore()
@@ -120,6 +114,10 @@ const totalProjects = getTotalProjects
 const featuredProjects = getFeaturedProjectsCount
 const uniqueTechnologies = getUniqueTechnologies
 const allTechnologies = getAllTechnologies
+
+const technologyNames = computed(() =>
+  Array.from(new Set(allTechnologies.value.map(t => t.name)))
+)
 </script>
 
 <style scoped>
@@ -215,18 +213,6 @@ const allTechnologies = getAllTechnologies
   background-color: var(--bg-secondary);
 }
 
-.tech-cloud {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  align-items: center;
-  gap: var(--spacing-md);
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-
-
 /* Responsive */
 @media (max-width: 1024px) {
   .projects-grid.featured {
@@ -251,10 +237,6 @@ const allTechnologies = getAllTechnologies
   .stat-number {
     font-size: var(--font-size-2xl);
   }
-
-  .tech-cloud {
-    gap: var(--spacing-sm);
-  }
 }
 
 @media (max-width: 480px) {
@@ -274,7 +256,6 @@ const allTechnologies = getAllTechnologies
   .stat-label {
     font-size: var(--font-size-sm);
   }
-
 }
 
 </style>


### PR DESCRIPTION
## Summary
- install `three` and `@types/three`
- add reusable `<TechGalaxy>` component rendering technology names on a 3D sphere with starfield and OrbitControls
- replace badge grid in Projects view with `<TechGalaxy>` and keep automatic text fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f0ac312c832d83daa2c3ba62161f