### PR TITLE
style: unify technology badge visuals

### DIFF
--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -242,7 +242,7 @@ const badgeClass = computed(() => {
 .tech-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--spacing-xs);
+  gap: var(--spacing-sm);
   margin-bottom: var(--spacing-lg);
 }
 

--- a/src/components/TechBadge.vue
+++ b/src/components/TechBadge.vue
@@ -21,11 +21,13 @@ const sizeClass = computed(() => `tech-badge--${props.size}`)
 .tech-badge {
   display: inline-block;
   border-radius: var(--border-radius-md);
-  border: 1px solid rgba(76, 175, 80, 0.2);
-  background-color: rgba(76, 175, 80, 0.1);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 30%, transparent);
+  background-color: color-mix(in srgb, var(--primary-color) 10%, transparent);
   color: var(--primary-dark);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
+  transition: background-color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .tech-badge--sm {
@@ -39,8 +41,21 @@ const sizeClass = computed(() => `tech-badge--${props.size}`)
 }
 
 :global(.dark) .tech-badge {
-  background-color: rgba(76, 175, 80, 0.2);
+  background-color: color-mix(in srgb, var(--primary-color) 20%, transparent);
   color: var(--primary-light);
-  border-color: rgba(76, 175, 80, 0.3);
+  border-color: color-mix(in srgb, var(--primary-color) 40%, transparent);
+}
+
+.tech-badge:hover,
+.tech-badge:focus-visible {
+  background-color: color-mix(in srgb, var(--primary-color) 20%, transparent);
+  border-color: color-mix(in srgb, var(--primary-color) 40%, transparent);
+  outline: none;
+}
+
+:global(.dark) .tech-badge:hover,
+:global(.dark) .tech-badge:focus-visible {
+  background-color: color-mix(in srgb, var(--primary-color) 30%, transparent);
+  border-color: color-mix(in srgb, var(--primary-color) 50%, transparent);
 }
 </style>

--- a/src/components/TechGalaxy.vue
+++ b/src/components/TechGalaxy.vue
@@ -39,7 +39,7 @@ import {
 } from 'three'
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js'
 import TechBadge from './TechBadge.vue'
-import { createTextSprite } from '../lib/createTextSprite'
+import { createTextSprite, disposeTextSpriteCache } from '../lib/createTextSprite'
 
 interface Props {
   technologies: string[]
@@ -134,6 +134,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('resize', onResize)
   container.value?.removeEventListener('pointermove', onPointerMove)
   container.value?.removeEventListener('click', onClick)
+  disposeTextSpriteCache()
 })
 
 function init() {

--- a/src/lib/createTextSprite.ts
+++ b/src/lib/createTextSprite.ts
@@ -1,54 +1,111 @@
 import { CanvasTexture, Sprite, SpriteMaterial } from 'three'
 
+interface CacheEntry {
+  texture: CanvasTexture
+  width: number
+  height: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+function toPx(value: string): number {
+  const trimmed = value.trim()
+  const rootFont = parseFloat(
+    getComputedStyle(document.documentElement).fontSize || '16px'
+  )
+  if (trimmed.endsWith('rem')) return parseFloat(trimmed) * rootFont
+  return parseFloat(trimmed)
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const h = hex.replace('#', '')
+  const bigint = parseInt(h, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+) {
+  ctx.beginPath()
+  ctx.moveTo(x + radius, y)
+  ctx.lineTo(x + width - radius, y)
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius)
+  ctx.lineTo(x + width, y + height - radius)
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height)
+  ctx.lineTo(x + radius, y + height)
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius)
+  ctx.lineTo(x, y + radius)
+  ctx.quadraticCurveTo(x, y, x + radius, y)
+  ctx.closePath()
+  ctx.fill()
+  ctx.stroke()
+}
+
 /**
  * Creates a Three.js Sprite containing the given text rendered on a canvas.
- * The sprite uses theme colors for contrast and a subtle background/border
- * to maintain legibility.
+ * Styles mirror the TechBadge component so DOM and 3D labels look identical.
  */
 export function createTextSprite(text: string): Sprite {
-  const canvas = document.createElement('canvas')
-  const ctx = canvas.getContext('2d')!
+  const dpr = window.devicePixelRatio || 1
+  const cacheKey = text
+  let entry = cache.get(cacheKey)
+  if (!entry) {
+    const canvas = document.createElement('canvas')
+    const ctx = canvas.getContext('2d')!
+    const root = getComputedStyle(document.documentElement)
 
-  const padding = 16
-  const maxWidth = 512
-  const rootStyles = getComputedStyle(document.documentElement)
-  const fontFamily = rootStyles.getPropertyValue('--font-family').trim() ||
-    'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
-  let fontSize = 48
+    const fontFamily = root.getPropertyValue('font-family').trim() ||
+      'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+    const fontSize = toPx(root.getPropertyValue('--font-size-xs')) || 12
+    const paddingX = toPx(root.getPropertyValue('--spacing-sm')) || 16
+    const paddingY = toPx(root.getPropertyValue('--spacing-xs')) || 8
+    const radius = toPx(root.getPropertyValue('--border-radius-md')) || 8
+    const textColor = root.getPropertyValue('--primary-dark').trim() || '#2E7D32'
+    const baseColor = root.getPropertyValue('--primary-color').trim() || '#4CAF50'
 
-  ctx.font = `${fontSize}px ${fontFamily}`
-  let textWidth = ctx.measureText(text).width
-
-  if (textWidth + padding * 2 > maxWidth) {
-    const scale = (maxWidth - padding * 2) / textWidth
-    fontSize = Math.floor(fontSize * scale)
     ctx.font = `${fontSize}px ${fontFamily}`
-    textWidth = ctx.measureText(text).width
+    const textWidth = ctx.measureText(text).width
+    const width = textWidth + paddingX * 2
+    const height = fontSize + paddingY * 2
+
+    canvas.width = width * dpr
+    canvas.height = height * dpr
+    ctx.scale(dpr, dpr)
+
+    ctx.font = `${fontSize}px ${fontFamily}`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+
+    ctx.fillStyle = hexToRgba(baseColor, 0.1)
+    ctx.strokeStyle = hexToRgba(baseColor, 0.3)
+    ctx.lineWidth = 1
+    drawRoundedRect(ctx, 0.5, 0.5, width - 1, height - 1, radius)
+
+    ctx.fillStyle = textColor
+    ctx.fillText(text, width / 2, height / 2)
+
+    const texture = new CanvasTexture(canvas)
+    entry = { texture, width, height }
+    cache.set(cacheKey, entry)
   }
 
-  canvas.width = textWidth + padding * 2
-  canvas.height = fontSize + padding * 2
-
-  ctx.font = `${fontSize}px ${fontFamily}`
-  ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
-
-  const textColor = rootStyles.getPropertyValue('--text-primary').trim() || '#fff'
-  const backgroundColor = 'rgba(0,0,0,0.4)'
-  const borderColor = 'rgba(255,255,255,0.3)'
-
-  ctx.fillStyle = backgroundColor
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
-  ctx.strokeStyle = borderColor
-  ctx.lineWidth = 1
-  ctx.strokeRect(0.5, 0.5, canvas.width - 1, canvas.height - 1)
-  ctx.fillStyle = textColor
-  ctx.fillText(text, canvas.width / 2, canvas.height / 2)
-
-  const texture = new CanvasTexture(canvas)
-  const material = new SpriteMaterial({ map: texture, transparent: true })
+  const material = new SpriteMaterial({ map: entry.texture, transparent: true })
   const sprite = new Sprite(material)
-  sprite.scale.set(canvas.width / 100, canvas.height / 100, 1)
+  sprite.scale.set(entry.width / 100, entry.height / 100, 1)
   sprite.userData.text = text
   return sprite
+}
+
+/** Clears cached textures to free GPU memory. */
+export function disposeTextSpriteCache() {
+  cache.forEach(e => e.texture.dispose())
+  cache.clear()
 }


### PR DESCRIPTION
## Summary
- refine TechBadge to use design tokens with consistent padding, radius and hover styles
- align project card tech tag spacing with global badge layout
- match 3D galaxy label sprites to DOM badges with token-based colors, dynamic sizing and texture cache

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b60acfd818832d839913c35a654c1f