### PR TITLE
Refactor login modal styling with theme tokens and i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ En modo fallback (sin WebGL) se mantiene el mismo gradiente detrás de la lista 
 - `autoRotateSpeed`: velocidad de rotación automática (por defecto más lenta).
 - `allowPause`: muestra un botón accesible para pausar o reanudar la animación.
 
+## Tokens de estilo del modal de login
+El modal de autenticación reutiliza los siguientes tokens del tema:
+
+- `--overlay-bg` para el fondo del backdrop.
+- `--bg-primary` y `--text-primary` para el contenedor.
+- `--primary-color` y `--danger-color` en bordes, botones y estados de error.
+- `--shadow-md` para la sombra del contenedor.
+- `--border-radius-lg` y `--border-radius-md` para los bordes redondeados.
+- `--spacing-2xl`, `--spacing-lg`, `--spacing-md` y `--spacing-sm` para el espaciado interno y externo.
+
 ## Cómo contribuir / modificar
 1. Agrega tu proyecto o skill en los archivos JSON de `src/data`.
 2. Incluye la traducción correspondiente en `src/i18n/en.json` y `es.json`.

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -33,6 +33,7 @@
   --bg-primary: var(--white);
   --bg-secondary: var(--light-gray);
   --bg-dark: var(--black);
+  --overlay-bg: rgba(0, 0, 0, 0.5);
   
   /* Sombras */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -1,20 +1,41 @@
 <template>
   <div v-if="modelValue" class="modal-backdrop" @click.self="close">
-    <div class="modal" role="dialog" aria-modal="true">
-      <h2>Iniciar sesión</h2>
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="login-title"
+    >
+      <h2 id="login-title">{{ t.auth.title }}</h2>
       <form @submit.prevent="submit">
-        <div class="field">
-          <label for="user">Usuario</label>
-          <input id="user" ref="userInput" v-model="username" />
+        <div class="form-group">
+          <label for="user">{{ t.auth.username }}</label>
+          <input
+            id="user"
+            ref="userInput"
+            v-model="username"
+            :class="{ error }"
+            autocomplete="username"
+          />
         </div>
-        <div class="field">
-          <label for="pass">Contraseña</label>
-          <input id="pass" type="password" v-model="password" />
+        <div class="form-group">
+          <label for="pass">{{ t.auth.password }}</label>
+          <input
+            id="pass"
+            type="password"
+            v-model="password"
+            :class="{ error }"
+            autocomplete="current-password"
+          />
         </div>
-        <p v-if="error" class="error">{{ error }}</p>
+        <p v-if="error" class="error-message" aria-live="polite">{{ error }}</p>
         <div class="buttons">
-          <button type="button" @click="close">Cancelar</button>
-          <button type="submit">Aceptar</button>
+          <button type="button" class="btn btn-secondary" @click="close">
+            {{ t.auth.cancel }}
+          </button>
+          <button type="submit" class="btn btn-primary">
+            {{ t.auth.accept }}
+          </button>
         </div>
       </form>
     </div>
@@ -25,6 +46,8 @@
 import { ref, watch, nextTick, onUnmounted } from 'vue'
 import { useAuthStore } from '../stores/auth'
 import { useRouter } from 'vue-router'
+import { useMainStore } from '../stores/main'
+import { storeToRefs } from 'pinia'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits(['update:modelValue'])
@@ -35,6 +58,8 @@ const error = ref('')
 const userInput = ref<HTMLInputElement | null>(null)
 const auth = useAuthStore()
 const router = useRouter()
+const store = useMainStore()
+const { t } = storeToRefs(store)
 
 const close = () => {
   emit('update:modelValue', false)
@@ -49,7 +74,7 @@ const submit = () => {
     close()
     router.push('/admin')
   } else {
-    error.value = result.error || 'Credenciales inválidas'
+    error.value = result.error || t.value.auth.errorInvalid
   }
 }
 
@@ -65,14 +90,17 @@ watch(
     if (val) {
       nextTick(() => userInput.value?.focus())
       window.addEventListener('keydown', handleKey)
+      document.body.style.overflow = 'hidden'
     } else {
       window.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
     }
   }
 )
 
 onUnmounted(() => {
   window.removeEventListener('keydown', handleKey)
+  document.body.style.overflow = ''
 })
 </script>
 
@@ -80,35 +108,85 @@ onUnmounted(() => {
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--overlay-bg);
+  backdrop-filter: blur(10px);
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--spacing-md);
 }
 
 .modal {
-  background: #fff;
-  padding: 1rem;
-  border-radius: 4px;
-  width: 300px;
-  max-width: 90%;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  padding: var(--spacing-2xl);
+  border-radius: var(--border-radius-lg);
+  width: 100%;
+  max-width: 480px;
+  box-shadow: var(--shadow-md);
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 90%);
+  transition: all var(--transition-normal);
 }
 
-.field {
+.form-group {
   display: flex;
   flex-direction: column;
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-lg);
+}
+
+.form-group label {
+  margin-bottom: var(--spacing-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+}
+
+.form-group input {
+  width: 100%;
+  padding: var(--spacing-md);
+  border: 2px solid color-mix(in srgb, var(--primary-color), transparent 80%);
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: all var(--transition-fast);
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color), transparent 90%);
+}
+
+.form-group input.error {
+  border-color: var(--danger-color);
+}
+
+.error-message {
+  color: var(--danger-color);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--spacing-sm);
 }
 
 .buttons {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+  flex-wrap: wrap;
 }
 
-.error {
-  color: red;
-  margin-bottom: 0.5rem;
+.buttons .btn {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 480px) {
+  .buttons {
+    flex-direction: column;
+  }
+  .buttons .btn {
+    width: 100%;
+  }
 }
 </style>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -171,5 +171,14 @@
     "switchToSpanish": "Switch to Spanish",
     "lightMode": "Light Mode",
     "darkMode": "Dark Mode"
+  },
+  "auth": {
+    "title": "Sign in",
+    "username": "Username",
+    "password": "Password",
+    "cancel": "Cancel",
+    "accept": "Sign in",
+    "errorInvalid": "Invalid credentials",
+    "hintDemo": "Demo: admin/admin"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -171,5 +171,14 @@
     "switchToSpanish": "Cambiar a Español",
     "lightMode": "Modo Claro",
     "darkMode": "Modo Oscuro"
+  },
+  "auth": {
+    "title": "Iniciar sesión",
+    "username": "Usuario",
+    "password": "Contraseña",
+    "cancel": "Cancelar",
+    "accept": "Aceptar",
+    "errorInvalid": "Credenciales inválidas",
+    "hintDemo": "Demo: admin/admin"
   }
 }


### PR DESCRIPTION
## Summary
- Restyle login modal to reuse global theme tokens and responsive layout
- Add authentication translations and connect modal to i18n store
- Document modal tokens in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb3c174504832db1ac8ed5842e993f