### PR TITLE
fix: ensure login modal overlays home

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ En modo fallback (sin WebGL) se mantiene el mismo gradiente detrás de la lista 
 El modal de autenticación reutiliza los siguientes tokens del tema:
 
 - `--overlay-bg` para el fondo del backdrop.
+- `--z-overlay` y `--z-modal` para el orden de apilamiento.
 - `--bg-primary` y `--text-primary` para el contenedor.
 - `--primary-color` y `--danger-color` en bordes, botones y estados de error.
 - `--shadow-md` para la sombra del contenedor.

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -34,7 +34,12 @@
   --bg-secondary: var(--light-gray);
   --bg-dark: var(--black);
   --overlay-bg: rgba(0, 0, 0, 0.5);
-  
+
+  /* Niveles de superposición */
+  --z-header: 1000;
+  --z-overlay: 2000;
+  --z-modal: 2100;
+
   /* Sombras */
   --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
   --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.15);

--- a/src/components/LoginModal.vue
+++ b/src/components/LoginModal.vue
@@ -1,45 +1,47 @@
 <template>
-  <div v-if="modelValue" class="modal-backdrop" @click.self="close">
-    <div
-      class="modal"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="login-title"
-    >
-      <h2 id="login-title">{{ t.auth.title }}</h2>
-      <form @submit.prevent="submit">
-        <div class="form-group">
-          <label for="user">{{ t.auth.username }}</label>
-          <input
-            id="user"
-            ref="userInput"
-            v-model="username"
-            :class="{ error }"
-            autocomplete="username"
-          />
-        </div>
-        <div class="form-group">
-          <label for="pass">{{ t.auth.password }}</label>
-          <input
-            id="pass"
-            type="password"
-            v-model="password"
-            :class="{ error }"
-            autocomplete="current-password"
-          />
-        </div>
-        <p v-if="error" class="error-message" aria-live="polite">{{ error }}</p>
-        <div class="buttons">
-          <button type="button" class="btn btn-secondary" @click="close">
-            {{ t.auth.cancel }}
-          </button>
-          <button type="submit" class="btn btn-primary">
-            {{ t.auth.accept }}
-          </button>
-        </div>
-      </form>
+  <teleport to="body">
+    <div v-if="modelValue" class="modal-backdrop" @click.self="close">
+      <div
+        class="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="login-title"
+      >
+        <h2 id="login-title">{{ t.auth.title }}</h2>
+        <form @submit.prevent="submit">
+          <div class="form-group">
+            <label for="user">{{ t.auth.username }}</label>
+            <input
+              id="user"
+              ref="userInput"
+              v-model="username"
+              :class="{ error }"
+              autocomplete="username"
+            />
+          </div>
+          <div class="form-group">
+            <label for="pass">{{ t.auth.password }}</label>
+            <input
+              id="pass"
+              type="password"
+              v-model="password"
+              :class="{ error }"
+              autocomplete="current-password"
+            />
+          </div>
+          <p v-if="error" class="error-message" aria-live="polite">{{ error }}</p>
+          <div class="buttons">
+            <button type="button" class="btn btn-secondary" @click="close">
+              {{ t.auth.cancel }}
+            </button>
+            <button type="submit" class="btn btn-primary">
+              {{ t.auth.accept }}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
-  </div>
+  </teleport>
 </template>
 
 <script setup lang="ts">
@@ -114,9 +116,11 @@ onUnmounted(() => {
   align-items: center;
   justify-content: center;
   padding: var(--spacing-md);
+  z-index: var(--z-overlay);
 }
 
 .modal {
+  position: relative;
   background: var(--bg-primary);
   color: var(--text-primary);
   padding: var(--spacing-2xl);
@@ -126,6 +130,7 @@ onUnmounted(() => {
   box-shadow: var(--shadow-md);
   border: 1px solid color-mix(in srgb, var(--primary-color), transparent 90%);
   transition: all var(--transition-normal);
+  z-index: var(--z-modal);
 }
 
 .form-group {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -118,7 +118,7 @@ onUnmounted(() => {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: var(--z-header);
   background-color: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(10px);
   transition: all var(--transition-normal);
@@ -206,7 +206,7 @@ onUnmounted(() => {
   justify-content: center;
   min-width: 40px;
   height: 40px;
-  z-index: 999;
+  z-index: calc(var(--z-header) - 1);
 }
 
 .control-btn:hover {


### PR DESCRIPTION
## Summary
- teleport login modal and backdrop to `<body>`
- add z-index design tokens and apply to modal overlay and navbar
- document modal layering tokens

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bb3e76d2fc832d8cf7c56fa563eed6