### PR TITLE
feat: persist admin session and logout

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -40,9 +40,20 @@
             <span v-else>🌙</span>
           </button>
 
+          <!-- Icono de cierre de sesión -->
+          <button
+            v-if="isLoggedIn"
+            @click="handleLogout"
+            class="control-btn logout-btn"
+            :title="t.actions.signOut"
+            :aria-label="t.actions.signOut"
+          >
+            🚪
+          </button>
+
           <!-- Botón hamburguesa para menú móvil -->
-          <button 
-            @click="toggleMenu" 
+          <button
+            @click="toggleMenu"
             class="control-btn mobile-menu-btn"
             :class="{ active: isMenuOpen }"
           >
@@ -73,10 +84,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, computed } from 'vue'
 import { useMainStore } from '../stores/main'
 import AppLogo from './AppLogo.vue'
 import { storeToRefs } from 'pinia'
+import { useAuthStore } from '../stores/auth'
+import { useRouter } from 'vue-router'
 
 const emit = defineEmits(['open-login'])
 
@@ -85,11 +98,22 @@ const store = useMainStore()
 const { currentLanguage, isDarkMode, isMenuOpen, t } = storeToRefs(store)
 const { toggleLanguage, toggleDarkMode, toggleMenu, closeMenu } = store
 
+// Autenticación
+const auth = useAuthStore()
+const { isLoggedIn } = storeToRefs(auth)
+const { logout } = auth
+const router = useRouter()
+
+const handleLogout = () => {
+  logout()
+  router.push('/')
+}
+
 // Estado local para aplicar estilo cuando se hace scroll
 const isScrolled = ref(false)
 
-// Rutas que se muestran en la navegación
-const menuItems = [
+// Rutas base de navegación
+const baseMenuItems = [
   { name: 'home', path: '/' },
   { name: 'about', path: '/sobre-mi' },
   { name: 'education', path: '/educacion' },
@@ -97,6 +121,15 @@ const menuItems = [
   { name: 'projects', path: '/proyectos' },
   { name: 'contact', path: '/contacto' }
 ]
+
+// Menú dinámico que incluye el panel administrativo si hay sesión
+const menuItems = computed(() => {
+  const items = [...baseMenuItems]
+  if (isLoggedIn.value) {
+    items.push({ name: 'adminPanel', path: '/admin' })
+  }
+  return items
+})
 
 // Detecta desplazamiento para cambiar estilo del header
 const handleScroll = () => {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -5,7 +5,8 @@
     "education": "Education",
     "skills": "Skills",
     "projects": "Projects",
-    "contact": "Contact"
+    "contact": "Contact",
+    "adminPanel": "Admin Panel"
   },
   "hero": {
     "greeting": "Hi, I'm",
@@ -180,5 +181,8 @@
     "accept": "Sign in",
     "errorInvalid": "Invalid credentials",
     "hintDemo": "Demo: admin/admin"
+  },
+  "actions": {
+    "signOut": "Sign out of admin mode"
   }
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -5,7 +5,8 @@
     "education": "Educación",
     "skills": "Habilidades",
     "projects": "Proyectos",
-    "contact": "Contacto"
+    "contact": "Contacto",
+    "adminPanel": "Panel Administrativo"
   },
   "hero": {
     "greeting": "Hola, soy",
@@ -180,5 +181,8 @@
     "accept": "Aceptar",
     "errorInvalid": "Credenciales inválidas",
     "hintDemo": "Demo: admin/admin"
+  },
+  "actions": {
+    "signOut": "Salir del modo administrador"
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -192,7 +192,7 @@ router.beforeEach((to, from, next) => {
   
   // Verificar autenticación si es requerida
   if (to.meta.requiresAuth) {
-    if (authStore.isAdmin) {
+    if (authStore.isLoggedIn) {
       next()
     } else {
       next('/')

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,21 +1,32 @@
 import { defineStore } from 'pinia'
 
 export const useAuthStore = defineStore('auth', {
-  state: () => ({
-    isAdmin: localStorage.getItem('isAdmin') === 'true'
-  }),
+  state: () => {
+    const username = localStorage.getItem('app.auth.username') || ''
+    const loginAt = localStorage.getItem('app.auth.loginAt') || ''
+    const isLoggedIn = username !== '' && loginAt !== ''
+    return {
+      isLoggedIn,
+      username: isLoggedIn ? username : ''
+    }
+  },
   actions: {
     login(username: string, password: string) {
       if (username === 'admin' && password === 'admin') {
-        this.isAdmin = true
-        localStorage.setItem('isAdmin', 'true')
+        this.isLoggedIn = true
+        this.username = username
+        localStorage.setItem('app.auth.username', username)
+        localStorage.setItem('app.auth.loginAt', new Date().toISOString())
         return { ok: true as const }
       }
       return { ok: false as const, error: 'Credenciales inválidas' }
     },
     logout() {
-      this.isAdmin = false
-      localStorage.removeItem('isAdmin')
+      this.isLoggedIn = false
+      this.username = ''
+      localStorage.removeItem('app.auth.username')
+      localStorage.removeItem('app.auth.loginAt')
     }
   }
 })
+


### PR DESCRIPTION
## Summary
- store admin sessions in localStorage and auto-init auth state
- show Admin Panel menu and logout icon when logged in
- add i18n strings for admin panel and sign out in ES/EN

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb42184a6c832db5701104cac8f114