### PR TITLE
Refactor experience store and sync timeline

### DIFF
--- a/src/components/admin/ExperienceModal.vue
+++ b/src/components/admin/ExperienceModal.vue
@@ -191,12 +191,20 @@ const save = () => {
   if (!form.start || !form.role.es || !form.role.en || !form.company || !form.summary.es || !form.summary.en)
     return
   if (!form.current && form.end && form.end < form.start) return
-  form.updatedAt = new Date().toISOString()
   if (isEdit.value) {
-    experienceStore.updateExperience({ ...form })
+    experienceStore.update({ ...form })
   } else {
-    form.id = experienceStore.getNextId()
-    experienceStore.addExperience({ ...form })
+    experienceStore.create({
+      start: form.start,
+      end: form.end,
+      current: form.current,
+      role: form.role,
+      company: form.company,
+      location: form.location,
+      summary: form.summary,
+      technologies: form.technologies,
+      featured: form.featured
+    })
   }
   emit('update:modelValue', false)
 }

--- a/src/components/admin/ExperienceTable.vue
+++ b/src/components/admin/ExperienceTable.vue
@@ -16,9 +16,9 @@
       <table class="admin-table" aria-labelledby="experience-heading">
         <thead>
           <tr>
-            <th @click="toggleSort('id')">ID</th>
+            <th>ID</th>
             <th>{{ t.admin.period }}</th>
-            <th @click="toggleSort('role')">{{ t.admin.roleEs }}</th>
+            <th>{{ t.admin.roleEs }}</th>
             <th>{{ t.admin.roleEn }}</th>
             <th>{{ t.admin.company }}</th>
             <th>{{ t.admin.current }}</th>
@@ -27,7 +27,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="exp in sorted" :key="exp.id">
+          <tr v-for="exp in exps" :key="exp.id">
             <td>{{ exp.id }}</td>
             <td>{{ formatPeriod(exp) }}</td>
             <td>{{ exp.role.es }}</td>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import { useExperienceStore, useMainStore } from '../../stores'
 import { storeToRefs } from 'pinia'
 
@@ -57,31 +57,8 @@ const experienceStore = useExperienceStore()
 const mainStore = useMainStore()
 const { t } = storeToRefs(mainStore)
 
-const sortKey = ref<'id' | 'role'>('id')
-const sortAsc = ref(true)
-
-const exps = computed(() => experienceStore.getExperiences)
-
-const sorted = computed(() => {
-  return [...exps.value].sort((a, b) => {
-    if (sortKey.value === 'role') {
-      const aTitle = a.role.es.toLowerCase()
-      const bTitle = b.role.es.toLowerCase()
-      return sortAsc.value
-        ? aTitle.localeCompare(bTitle)
-        : bTitle.localeCompare(aTitle)
-    }
-    return sortAsc.value ? a.id - b.id : b.id - a.id
-  })
-})
-
-const toggleSort = (key: 'id' | 'role') => {
-  if (sortKey.value === key) sortAsc.value = !sortAsc.value
-  else {
-    sortKey.value = key
-    sortAsc.value = true
-  }
-}
+// Obtiene la lista ordenada directamente del store
+const exps = computed(() => experienceStore.getSortedExperiences.value)
 
 const formatPeriod = (exp: any) => {
   const end = exp.current || !exp.end ? t.value.admin.present : exp.end

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -66,10 +66,13 @@
           >
             <div class="timeline-marker"></div>
             <div class="timeline-content">
-              <div class="timeline-date">{{ item.date }}</div>
+              <div class="timeline-date">{{ item.period }}</div>
               <h3>{{ item.role }}</h3>
               <h4>{{ item.company }}</h4>
               <p>{{ item.description }}</p>
+              <ul class="timeline-tech">
+                <li v-for="tech in item.technologies" :key="tech">{{ tech }}</li>
+              </ul>
             </div>
           </div>
         </div>
@@ -188,6 +191,7 @@
 import { computed } from "vue";
 import { useMainStore } from "../stores/main";
 import { usePersonalStore } from "../stores/personal";
+import { useExperienceStore } from "../stores";
 // Importamos el modelo del dominio
 import type { PersonalData } from "../domain/personal/Personal";
 import { storeToRefs } from "pinia";
@@ -201,11 +205,17 @@ const { getPersonal } = storeToRefs(personalStore);
 // Datos personales provenientes de la capa de dominio
 const personalData: PersonalData = getPersonal.value;
 
-// Lista de eventos de la línea de tiempo profesional
-const journeyItems = computed(() => {
-  const { title, ...items } = t.value.about.journey;
-  return Object.values(items);
-});
+// Lista de eventos de la línea de tiempo profesional sincronizada con el store
+const experienceStore = useExperienceStore();
+const journeyItems = computed(() =>
+  experienceStore.publicList.value.map(exp => ({
+    period: `${exp.start} - ${exp.current || !exp.end ? t.value.admin.present : exp.end}`,
+    role: getTranslatedText(exp.role),
+    company: exp.company,
+    description: getTranslatedText(exp.summary),
+    technologies: exp.technologies
+  }))
+);
 </script>
 
 <style scoped>
@@ -417,6 +427,23 @@ const journeyItems = computed(() => {
   color: var(--text-secondary);
   line-height: 1.6;
   margin: 0;
+}
+
+.timeline-tech {
+  margin-top: var(--spacing-sm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-tech li {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  padding: 2px 6px;
+  border-radius: var(--border-radius-sm);
+  font-size: var(--font-size-sm);
 }
 
 .goals {

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -102,16 +102,17 @@ const openEditExp = (id: number) => {
 }
 
 const openDuplicateExp = (id: number) => {
-  const exp = experienceStore.duplicateExperience(id)
-  if (exp) {
-    selectedExperience.value = exp
+  const newId = experienceStore.duplicate(id)
+  if (newId !== undefined) {
+    const exp = experienceStore.getExperienceById(newId)
+    selectedExperience.value = exp || null
     modalExpOpen.value = true
   }
 }
 
 const confirmDeleteExp = (id: number) => {
   if (window.confirm(t.value.admin.confirmDelete)) {
-    experienceStore.removeExperience(id)
+    experienceStore.remove(id)
   }
 }
 


### PR DESCRIPTION
## Summary
- Refactor experience store to use reactive array with debounced localStorage persistence and CRUD helpers
- Simplify experience admin table to consume sorted store data
- Drive About timeline from store and expose technologies with styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb742dc218832da483b434f88d6aa5