### PR TITLE
feat: improve experience store loading and modal

### DIFF
--- a/src/components/admin/ExperienceModal.vue
+++ b/src/components/admin/ExperienceModal.vue
@@ -9,7 +9,11 @@
         ref="modalRef"
       >
         <h2 id="experience-modal-title">
-          {{ isEdit ? t.admin.experience.editTitle : t.admin.experience.newTitle }}
+          {{
+            isEdit
+              ? t.admin.experience.modal.titleEdit
+              : t.admin.experience.modal.titleNew
+          }}
         </h2>
         <form @submit.prevent="save">
           <section class="form-section">
@@ -70,14 +74,14 @@
               </div>
               <div class="tech-input">
                 <input v-model="techInput" @keydown.enter.prevent="addTech" />
-                <button type="button" class="btn btn-secondary" @click="addTech">{{ t.admin.modal.addTech }}</button>
+                <button type="button" class="btn btn-secondary" @click="addTech">{{ t.admin.experience.modal.addTech }}</button>
               </div>
             </div>
           </section>
 
           <div class="buttons">
-            <button type="button" class="btn btn-secondary" @click="cancel">{{ t.admin.modal.cancel }}</button>
-            <button type="submit" class="btn btn-primary">{{ t.admin.modal.save }}</button>
+            <button type="button" class="btn btn-secondary" @click="cancel">{{ t.admin.experience.modal.cancel }}</button>
+            <button type="submit" class="btn btn-primary">{{ t.admin.experience.modal.save }}</button>
           </div>
         </form>
       </div>
@@ -86,7 +90,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref, watch, computed, nextTick, onUnmounted } from 'vue'
+import { reactive, ref, watch, computed, nextTick, onUnmounted, onMounted } from 'vue'
 import { useExperienceStore, useMainStore } from '../../stores'
 import type { Experience } from '../../interfaces'
 import { storeToRefs } from 'pinia'
@@ -157,6 +161,10 @@ onUnmounted(() => {
   document.body.style.overflow = ''
 })
 
+onMounted(async () => {
+  await experienceStore.ensureLoaded()
+})
+
 const trapFocus = (e: KeyboardEvent) => {
   if (e.key !== 'Tab' || !modalRef.value) return
   const focusables = modalRef.value.querySelectorAll<HTMLElement>(
@@ -219,40 +227,80 @@ const save = () => {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: var(--spacing-lg);
+  padding: var(--spacing-md);
+  z-index: var(--z-overlay);
 }
 .modal {
+  position: relative;
   background: var(--bg-primary);
   color: var(--text-primary);
-  padding: var(--spacing-lg);
+  padding: var(--spacing-2xl);
+  border-radius: var(--border-radius-lg);
+  width: 100%;
+  max-width: 700px;
   max-height: 90vh;
   overflow-y: auto;
-  width: 600px;
-  outline: none;
+  box-shadow: var(--shadow-md);
+  border: 1px solid color-mix(in srgb, var(--primary-color), transparent 90%);
+  transition: all var(--transition-normal);
+  z-index: var(--z-modal);
 }
 .form-section {
-  margin-bottom: var(--spacing-md);
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-lg);
 }
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+}
+.form-group label {
+  margin-bottom: var(--spacing-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+}
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: var(--spacing-md);
+  border: 2px solid color-mix(in srgb, var(--primary-color), transparent 80%);
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-base);
+  font-family: inherit;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  transition: all var(--transition-fast);
+}
+.form-group textarea {
+  min-height: 80px;
+}
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color), transparent 90%);
 }
 .chips {
   display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-xs);
 }
 .chip {
-  background: var(--bg-secondary);
-  padding: 2px 6px;
-  border-radius: 4px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
+  padding: 0 var(--spacing-xs);
+  border-radius: var(--border-radius-md);
+  background: var(--primary-color);
+  color: var(--bg-primary);
+  font-size: var(--font-size-sm);
+}
+.chip button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  margin-left: var(--spacing-xs);
 }
 .tech-input {
   display: flex;
@@ -263,5 +311,17 @@ const save = () => {
   justify-content: flex-end;
   gap: var(--spacing-sm);
   margin-top: var(--spacing-md);
+  flex-wrap: wrap;
+}
+.buttons .btn {
+  flex: 1 1 auto;
+}
+@media (max-width: 480px) {
+  .buttons {
+    flex-direction: column;
+  }
+  .buttons .btn {
+    width: 100%;
+  }
 }
 </style>

--- a/src/components/admin/ExperienceTable.vue
+++ b/src/components/admin/ExperienceTable.vue
@@ -27,7 +27,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr v-for="exp in exps" :key="exp.id">
+          <tr v-for="exp in exps.value" :key="exp.id">
             <td>{{ exp.id }}</td>
             <td>{{ formatPeriod(exp) }}</td>
             <td>{{ exp.role.es }}</td>
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useExperienceStore, useMainStore } from '../../stores'
 import { storeToRefs } from 'pinia'
 
@@ -58,7 +58,11 @@ const mainStore = useMainStore()
 const { t } = storeToRefs(mainStore)
 
 // Obtiene la lista ordenada directamente del store
-const exps = computed(() => experienceStore.getSortedExperiences.value)
+const exps = computed(() => experienceStore.sortedByPeriod)
+
+onMounted(async () => {
+  await experienceStore.ensureLoaded()
+})
 
 const formatPeriod = (exp: any) => {
   const end = exp.current || !exp.end ? t.value.admin.present : exp.end

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -32,31 +32,8 @@
       "longTitle": "Long Term"
     },
     "journey": {
-      "title": "Professional Journey",
-      "item1": {
-        "date": "2024 - Present",
-        "role": "Senior Front-End Developer",
-        "company": "Sye Software (SAT)",
-        "description": "Responsible for the front-end of SAT's SICOJ Consultations module. Built reusable Svelte components with TypeScript, integrated RESTful services from .NET 6 MVC and managed state with Redux. Recognized for delivering the most advanced module and keeping the project on track without direct support. Technologies: Svelte, TypeScript, Redux, .NET 6 MVC, GitLab and Docker."
-      },
-      "item2": {
-        "date": "2022 - 2024",
-        "role": "Full Stack Developer",
-        "company": "Towa Software",
-        "description": "Served as bridge between external APIs and the frontend. Designed and consumed REST APIs, implemented .NET 6 MVC with Entity Framework and LINQ managing async programming and dependency injection. Built reactive Razor interfaces with Vue.js and performed automated testing with Selenium. Technologies: .NET 6 MVC, Entity Framework, LINQ, C#, Vue.js, Razor, Selenium and SQL Server."
-      },
-      "item3": {
-        "date": "2021 - 2022",
-        "role": "Full Stack Developer (Internship)",
-        "company": "StrApps Consulting",
-        "description": "Internship designing .NET 6 MVC views with jQuery and Bootstrap for a collections credit model. Created WordPress sites and handled version control in GitHub under Scrum methodology. Technologies: .NET 6 MVC, jQuery, Bootstrap, WordPress and GitHub."
-      },
-      "item4": {
-        "date": "2016 - 2022",
-        "role": "Computer Engineering",
-        "company": "Tecnológico de Estudios Superiores de Ecatepec",
-        "description": "Graduated with professional license. Strong background in software development, databases and development methodologies."
-      }
+      "title": "My Professional Journey",
+      "empty": "No experiences"
     },
     "interestsTitle": "Interests and Passions",
     "softSkills": {
@@ -177,8 +154,13 @@
     "experience": {
       "header": "Professional Experience Management",
       "new": "New Experience",
-      "newTitle": "New Experience",
-      "editTitle": "Edit Experience"
+      "modal": {
+        "titleNew": "New Experience",
+        "titleEdit": "Edit Experience",
+        "save": "Save",
+        "cancel": "Cancel",
+        "addTech": "Add"
+      }
     },
     "titleEs": "Title ES",
     "titleEn": "Title EN",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -33,30 +33,7 @@
     },
     "journey": {
       "title": "Mi Trayectoria Profesional",
-      "item1": {
-        "date": "2024 - Presente",
-        "role": "Front-End Developer Senior",
-        "company": "Sye Software (SAT)",
-        "description": "Responsable único del Front-End del módulo de Consultas en el sistema SICOJ del SAT. Desarrollé componentes reutilizables en Svelte y TypeScript, integré servicios RESTful desde .NET 6 MVC y gestioné el estado con Redux. Reconocido por entregar el módulo más avanzado y mantener el ritmo del proyecto sin apoyo directo. Tecnologías: Svelte, TypeScript, Redux, .NET 6 MVC, GitLab y Docker."
-      },
-      "item2": {
-        "date": "2022 - 2024",
-        "role": "Full Stack Developer",
-        "company": "Towa Software",
-        "description": "Actué como puente entre APIs externas y el Front-End. Diseñé y consumí APIs REST, implementé .NET 6 MVC con Entity Framework y LINQ gestionando asincronía e inyección de dependencias. Construí interfaces reactivas en Razor con Vue.js y realicé pruebas automatizadas con Selenium. Tecnologías: .NET 6 MVC, Entity Framework, LINQ, C#, Vue.js, Razor, Selenium y SQL Server."
-      },
-      "item3": {
-        "date": "2021 - 2022",
-        "role": "Full Stack Developer (Prácticas)",
-        "company": "StrApps Consulting",
-        "description": "Prácticas diseñando vistas en .NET 6 MVC con jQuery y Bootstrap para un modelo de crédito de cobranzas. Creé sitios WordPress y controlé versiones en GitHub bajo metodología Scrum. Tecnologías: .NET 6 MVC, jQuery, Bootstrap, WordPress y GitHub."
-      },
-      "item4": {
-        "date": "2016 - 2022",
-        "role": "Ingeniería en Informática",
-        "company": "Tecnológico de Estudios Superiores de Ecatepec",
-        "description": "Titulado con cédula profesional. Formación sólida en desarrollo de software, bases de datos y metodologías de desarrollo."
-      }
+      "empty": "No hay experiencias"
     },
     "interestsTitle": "Intereses y Pasiones",
     "softSkills": {
@@ -177,8 +154,13 @@
     "experience": {
       "header": "Gestión de Experiencia Profesional",
       "new": "Nueva Experiencia",
-      "newTitle": "Nueva Experiencia",
-      "editTitle": "Editar Experiencia"
+      "modal": {
+        "titleNew": "Nueva Experiencia",
+        "titleEdit": "Editar Experiencia",
+        "save": "Guardar",
+        "cancel": "Cancelar",
+        "addTech": "Agregar"
+      }
     },
     "titleEs": "Título ES",
     "titleEn": "Título EN",

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -57,9 +57,12 @@
       <!-- Professional Journey -->
       <section class="journey section">
         <h2 class="section-title">{{ t.about.journey.title }}</h2>
-        <div class="journey-timeline">
+        <div
+          class="journey-timeline"
+          v-if="Array.isArray(journeyItems.value)"
+        >
           <div
-            v-for="(item, index) in journeyItems"
+            v-for="(item, index) in journeyItems.value"
             :key="index"
             class="timeline-item"
             :class="index % 2 === 0 ? 'animate-fadeInLeft' : 'animate-fadeInRight'"
@@ -76,6 +79,7 @@
             </div>
           </div>
         </div>
+        <p v-else>{{ t.about.journey.empty }}</p>
       </section>
 
       <!-- Goals & Objectives -->
@@ -188,7 +192,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted } from "vue";
 import { useMainStore } from "../stores/main";
 import { usePersonalStore } from "../stores/personal";
 import { useExperienceStore } from "../stores";
@@ -207,15 +211,20 @@ const personalData: PersonalData = getPersonal.value;
 
 // Lista de eventos de la línea de tiempo profesional sincronizada con el store
 const experienceStore = useExperienceStore();
-const journeyItems = computed(() =>
-  experienceStore.publicList.value.map(exp => ({
+onMounted(async () => {
+  await experienceStore.ensureLoaded();
+});
+
+const journeyItems = computed(() => {
+  const list = experienceStore.publicList.value || [];
+  return list.map(exp => ({
     period: `${exp.start} - ${exp.current || !exp.end ? t.value.admin.present : exp.end}`,
     role: getTranslatedText(exp.role),
     company: exp.company,
     description: getTranslatedText(exp.summary),
     technologies: exp.technologies
-  }))
-);
+  }));
+});
 </script>
 
 <style scoped>

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -123,7 +123,10 @@ const handleShortcut = (e: KeyboardEvent) => {
   }
 }
 
-onMounted(() => window.addEventListener('keydown', handleShortcut))
+onMounted(async () => {
+  await experienceStore.ensureLoaded()
+  window.addEventListener('keydown', handleShortcut)
+})
 onBeforeUnmount(() => window.removeEventListener('keydown', handleShortcut))
 </script>
 


### PR DESCRIPTION
## Summary
- ensure experience store always provides arrays and loads data on demand
- hydrate experience data in admin and about sections before rendering
- restyle and translate experience modal to match project modal

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68bb814076cc832d816cd739e283d539