### PR TITLE
Refactor admin tables for language-aware content

### DIFF
--- a/src/components/admin/CertificationsTable.vue
+++ b/src/components/admin/CertificationsTable.vue
@@ -13,7 +13,8 @@
         <thead>
             <tr>
               <th>ID</th>
-              <th>{{ t.admin.titleEs }}</th>
+              <th>{{ t.admin.title }}</th>
+              <th>{{ t.admin.description }}</th>
               <th>{{ t.admin.provider }}</th>
               <th>{{ t.admin.icon }}</th>
               <th class="sticky-col">{{ t.admin.actions }}</th>
@@ -22,7 +23,8 @@
         <tbody>
             <tr v-for="cert in rows" :key="cert.id">
               <td>{{ cert.id }}</td>
-              <td>{{ cert.title.es }}</td>
+              <td>{{ cert.title[lang] ?? cert.title.es }}</td>
+              <td>{{ cert.description[lang] ?? cert.description.es }}</td>
               <td>{{ cert.provider }}</td>
               <td>{{ cert.icon }}</td>
               <td class="actions sticky-col">
@@ -45,7 +47,8 @@ import { storeToRefs } from 'pinia'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const certificationStore = useCertificationStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 const { publicList } = storeToRefs(certificationStore)
 
 const rows = publicList

--- a/src/components/admin/ExperienceTable.vue
+++ b/src/components/admin/ExperienceTable.vue
@@ -18,8 +18,7 @@
           <tr>
             <th>ID</th>
             <th>{{ t.admin.period }}</th>
-            <th>{{ t.admin.roleEs }}</th>
-            <th>{{ t.admin.roleEn }}</th>
+            <th>{{ t.admin.role }}</th>
             <th>{{ t.admin.company }}</th>
             <th>{{ t.admin.current }}</th>
             <th>{{ t.admin.featured }}</th>
@@ -30,8 +29,7 @@
           <tr v-for="exp in rows" :key="exp.id">
             <td>{{ exp.id }}</td>
             <td>{{ formatPeriod(exp) }}</td>
-            <td>{{ exp.role.es }}</td>
-            <td>{{ exp.role.en }}</td>
+            <td>{{ exp.role[lang] ?? exp.role.es }}</td>
             <td>{{ exp.company }}</td>
             <td>{{ exp.current ? t.admin.yes : t.admin.no }}</td>
             <td>{{ exp.featured ? t.admin.yes : t.admin.no }}</td>
@@ -55,7 +53,8 @@ import { storeToRefs } from 'pinia'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const experienceStore = useExperienceStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 const { sortedByPeriod } = storeToRefs(experienceStore)
 
 // Lista reactiva de experiencias del store

--- a/src/components/admin/ProjectsTable.vue
+++ b/src/components/admin/ProjectsTable.vue
@@ -19,8 +19,7 @@
         <thead>
           <tr>
             <th @click="toggleSort('id')">ID</th>
-            <th @click="toggleSort('title')">{{ t.admin.titleEs }}</th>
-            <th>{{ t.admin.titleEn }}</th>
+            <th @click="toggleSort('title')">{{ t.admin.title }}</th>
             <th>{{ t.admin.company }}</th>
             <th>{{ t.admin.featured }}</th>
             <th>{{ t.admin.tech }}</th>
@@ -30,8 +29,7 @@
         <tbody>
           <tr v-for="project in sortedProjects" :key="project.id">
             <td>{{ project.id }}</td>
-            <td>{{ project.title.es }}</td>
-            <td>{{ project.title.en }}</td>
+            <td>{{ project.title[lang] ?? project.title.es }}</td>
             <td>{{ project.company || '-' }}</td>
             <td>{{ isFeatured(project.id) ? t.admin.yes : t.admin.no }}</td>
             <td>{{ project.technologies.join(', ') }}</td>
@@ -55,7 +53,8 @@ import { storeToRefs } from 'pinia'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const projectsStore = useProjectsStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 
 const sortKey = ref<'id' | 'title'>('id')
 const sortAsc = ref(true)
@@ -65,8 +64,8 @@ const projects = computed(() => projectsStore.getAllProjects)
 const sortedProjects = computed(() => {
   return [...projects.value].sort((a, b) => {
     if (sortKey.value === 'title') {
-      const aTitle = a.title.es.toLowerCase()
-      const bTitle = b.title.es.toLowerCase()
+      const aTitle = (a.title[lang.value] ?? a.title.es).toLowerCase()
+      const bTitle = (b.title[lang.value] ?? b.title.es).toLowerCase()
       return sortAsc.value
         ? aTitle.localeCompare(bTitle)
         : bTitle.localeCompare(aTitle)

--- a/src/components/admin/SoftSkillsTable.vue
+++ b/src/components/admin/SoftSkillsTable.vue
@@ -19,14 +19,14 @@
         <thead>
           <tr>
             <th @click="toggleSort('id')">ID</th>
-            <th @click="toggleSort('name')">{{ t.admin.titleEs }}</th>
+            <th @click="toggleSort('name')">{{ t.admin.name }}</th>
             <th class="sticky-col">{{ t.admin.actions }}</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="skill in rows" :key="skill.id">
             <td>{{ skill.id }}</td>
-            <td>{{ skill.name.es }}</td>
+            <td>{{ skill.name[lang] ?? skill.name.es }}</td>
             <td class="actions sticky-col">
               <button class="btn btn-secondary" @click="$emit('edit', skill.id)">{{ t.admin.edit }}</button>
               <button class="btn btn-secondary" @click="$emit('duplicate', skill.id)">{{ t.admin.duplicate }}</button>
@@ -47,7 +47,8 @@ import { useSoftSkillStore, useMainStore } from '../../stores'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const softStore = useSoftSkillStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 const { items } = storeToRefs(softStore)
 
 const sortKey = ref<'id' | 'name'>('id')
@@ -56,8 +57,8 @@ const sortAsc = ref(true)
 const rows = computed(() => {
   return [...items.value].sort((a, b) => {
     if (sortKey.value === 'name') {
-      const aName = a.name.es.toLowerCase()
-      const bName = b.name.es.toLowerCase()
+      const aName = (a.name[lang.value] ?? a.name.es).toLowerCase()
+      const bName = (b.name[lang.value] ?? b.name.es).toLowerCase()
       return sortAsc.value
         ? aName.localeCompare(bName)
         : bName.localeCompare(aName)

--- a/src/components/admin/TechnicalSkillsTable.vue
+++ b/src/components/admin/TechnicalSkillsTable.vue
@@ -19,9 +19,9 @@
         <thead>
           <tr>
             <th @click="toggleSort('id')">ID</th>
-            <th @click="toggleSort('name')">{{ t.admin.titleEs }}</th>
+            <th @click="toggleSort('name')">{{ t.admin.name }}</th>
             <th>{{ t.admin.category }}</th>
-            <th>{{ t.admin.levelEs }}</th>
+            <th>{{ t.admin.level }}</th>
             <th>{{ t.admin.percentage }}</th>
             <th>{{ t.admin.type }}</th>
             <th class="sticky-col">{{ t.admin.actions }}</th>
@@ -30,9 +30,9 @@
         <tbody>
           <tr v-for="skill in rows" :key="skill.id">
             <td>{{ skill.id }}</td>
-            <td>{{ skill.name.es }}</td>
+            <td>{{ skill.name[lang] ?? skill.name.es }}</td>
             <td>{{ skill.category }}</td>
-            <td>{{ skill.level.es }}</td>
+            <td>{{ skill.level[lang] ?? skill.level.es }}</td>
             <td>
               <div class="progress-bar">
                 <div class="progress-fill" :style="{ width: skill.percentage + '%' }" />
@@ -59,7 +59,8 @@ import { useTechnicalSkillsStore, useMainStore } from '../../stores'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const technicalStore = useTechnicalSkillsStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 const { items } = storeToRefs(technicalStore)
 
 const sortKey = ref<'id' | 'name'>('id')
@@ -68,8 +69,8 @@ const sortAsc = ref(true)
 const rows = computed(() => {
   return [...items.value].sort((a, b) => {
     if (sortKey.value === 'name') {
-      const aName = a.name.es.toLowerCase()
-      const bName = b.name.es.toLowerCase()
+      const aName = (a.name[lang.value] ?? a.name.es).toLowerCase()
+      const bName = (b.name[lang.value] ?? b.name.es).toLowerCase()
       return sortAsc.value
         ? aName.localeCompare(bName)
         : bName.localeCompare(aName)

--- a/src/components/admin/ToolsTable.vue
+++ b/src/components/admin/ToolsTable.vue
@@ -19,18 +19,18 @@
         <thead>
           <tr>
             <th @click="toggleSort('id')">ID</th>
-            <th @click="toggleSort('name')">{{ t.admin.titleEs }}</th>
+            <th @click="toggleSort('name')">{{ t.admin.name }}</th>
             <th>{{ t.admin.category }}</th>
-            <th>{{ t.admin.levelEs }}</th>
+            <th>{{ t.admin.level }}</th>
             <th class="sticky-col">{{ t.admin.actions }}</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="tool in rows" :key="tool.id">
             <td>{{ tool.id }}</td>
-            <td>{{ tool.name.es }}</td>
+            <td>{{ tool.name[lang] ?? tool.name.es }}</td>
             <td>{{ tool.category }}</td>
-            <td>{{ tool.level.es }}</td>
+            <td>{{ tool.level[lang] ?? tool.level.es }}</td>
             <td class="actions sticky-col">
               <button class="btn btn-secondary" @click="$emit('edit', tool.id)">{{ t.admin.edit }}</button>
               <button class="btn btn-secondary" @click="$emit('duplicate', tool.id)">{{ t.admin.duplicate }}</button>
@@ -51,7 +51,8 @@ import { useToolStore, useMainStore } from '../../stores'
 const emit = defineEmits(['create', 'edit', 'duplicate', 'delete'])
 const toolStore = useToolStore()
 const mainStore = useMainStore()
-const { t } = storeToRefs(mainStore)
+const { t, currentLanguage } = storeToRefs(mainStore)
+const lang = currentLanguage
 const { items } = storeToRefs(toolStore)
 
 const sortKey = ref<'id' | 'name'>('id')
@@ -60,8 +61,8 @@ const sortAsc = ref(true)
 const rows = computed(() => {
   return [...items.value].sort((a, b) => {
     if (sortKey.value === 'name') {
-      const aName = a.name.es.toLowerCase()
-      const bName = b.name.es.toLowerCase()
+      const aName = (a.name[lang.value] ?? a.name.es).toLowerCase()
+      const bName = (b.name[lang.value] ?? b.name.es).toLowerCase()
       return sortAsc.value
         ? aName.localeCompare(bName)
         : bName.localeCompare(aName)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -202,6 +202,11 @@
         "cancel": "Cancel"
       }
     },
+    "title": "Title",
+    "role": "Role",
+    "description": "Description",
+    "name": "Name",
+    "level": "Level",
     "titleEs": "Title ES",
     "titleEn": "Title EN",
     "company": "Company",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -202,6 +202,11 @@
         "cancel": "Cancelar"
       }
     },
+    "title": "Título",
+    "role": "Puesto",
+    "description": "Descripción",
+    "name": "Nombre",
+    "level": "Nivel",
     "titleEs": "Título ES",
     "titleEn": "Título EN",
     "company": "Empresa",


### PR DESCRIPTION
## Summary
- Show table headers and values in the selected language using `useMainStore`
- Add generic translation keys for common admin labels
- Display certification descriptions and remove duplicate language columns

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68bbc4cb7254832db1ffcc02db79bd80