### PR TITLE
feat: enable multiple contact entries and refresh profile modal

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -217,6 +217,8 @@
         "github": "GitHub",
         "otherLinks": "Other links",
         "add": "Add",
+        "addEmail": "Add email",
+        "addPhone": "Add phone",
         "remove": "Remove"
       }
     },

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -217,6 +217,8 @@
         "github": "GitHub",
         "otherLinks": "Otros enlaces",
         "add": "Añadir",
+        "addEmail": "Añadir correo",
+        "addPhone": "Añadir teléfono",
         "remove": "Eliminar"
       }
     },

--- a/src/stores/contact.ts
+++ b/src/stores/contact.ts
@@ -3,8 +3,8 @@ import { ref, computed, watch } from 'vue'
 import data from '../data/personal.json'
 
 export interface ContactInfo {
-  email: string
-  phone: string
+  emails: string[]
+  phones?: string[]
   location: { es: string; en: string }
   linkedin: string
   github: string
@@ -13,23 +13,44 @@ export interface ContactInfo {
 
 const STORAGE_KEY = 'contactInfo'
 
+const adapt = (raw: any): ContactInfo => {
+  const emails = Array.isArray(raw.emails)
+    ? raw.emails
+    : raw.email
+    ? [raw.email]
+    : []
+  const phones = Array.isArray(raw.phones)
+    ? raw.phones
+    : raw.phone
+    ? [raw.phone]
+    : []
+  return {
+    emails,
+    phones: phones.length ? phones : undefined,
+    location: raw.location || { es: '', en: '' },
+    linkedin: raw.linkedin || '',
+    github: raw.github || '',
+    otherLinks: raw.otherLinks || {}
+  }
+}
+
 const load = (): ContactInfo => {
-  if (typeof window === 'undefined') return data.contact as ContactInfo
+  if (typeof window === 'undefined') return adapt(data.contact)
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (raw) return JSON.parse(raw) as ContactInfo
+    if (raw) return adapt(JSON.parse(raw))
   } catch {
     /* ignore */
   }
-  return data.contact as ContactInfo
+  return adapt(data.contact)
 }
 
 export const useContactStore = defineStore('contact', () => {
   const contact = ref<ContactInfo>(load())
 
   const getContact = computed(() => contact.value)
-  const getEmail = computed(() => contact.value.email)
-  const getPhone = computed(() => contact.value.phone)
+  const getEmails = computed(() => contact.value.emails)
+  const getPhones = computed(() => contact.value.phones)
   const getLocation = computed(() => contact.value.location)
   const getLinkedin = computed(() => contact.value.linkedin)
   const getGithub = computed(() => contact.value.github)
@@ -57,8 +78,8 @@ export const useContactStore = defineStore('contact', () => {
   return {
     contact,
     getContact,
-    getEmail,
-    getPhone,
+    getEmails,
+    getPhones,
     getLocation,
     getLinkedin,
     getGithub,

--- a/src/views/Contact.vue
+++ b/src/views/Contact.vue
@@ -16,7 +16,7 @@
           <div class="contact-info animate-fadeInLeft">
             <h2>{{ t.contact.info }}</h2>
             <div class="info-items">
-              <div class="info-item">
+              <div class="info-item" v-if="contact.emails.length">
                 <div class="info-icon">
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M20,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V6C22,4.89 21.1,4 20,4M20,8L12,13L4,8V6L12,11L20,6V8Z"/>
@@ -24,11 +24,13 @@
                 </div>
                 <div class="info-content">
                   <h3>{{ t.contact.details.email }}</h3>
-                  <p>{{ contact.email }}</p>
+                  <p v-for="(email, idx) in contact.emails" :key="`email-${idx}`">
+                    {{ email }}
+                  </p>
                 </div>
               </div>
 
-              <div class="info-item">
+              <div class="info-item" v-if="contact.phones && contact.phones.length">
                 <div class="info-icon">
                   <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M6.62,10.79C8.06,13.62 10.38,15.94 13.21,17.38L15.41,15.18C15.69,14.9 16.08,14.82 16.43,14.93C17.55,15.3 18.75,15.5 20,15.5A1,1 0 0,1 21,16.5V20A1,1 0 0,1 20,21A17,17 0 0,1 3,4A1,1 0 0,1 4,3H7.5A1,1 0 0,1 8.5,4C8.5,5.25 8.7,6.45 9.07,7.57C9.18,7.92 9.1,8.31 8.82,8.59L6.62,10.79Z"/>
@@ -36,7 +38,9 @@
                 </div>
                 <div class="info-content">
                   <h3>{{ t.contact.details.phone }}</h3>
-                  <p>{{ contact.phone }}</p>
+                  <p v-for="(phone, idx) in contact.phones" :key="`phone-${idx}`">
+                    {{ phone }}
+                  </p>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- restyle profile modal to match admin modals
- store and persist multiple emails/phones
- show all contact methods in profile modal and contact page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbcbb5b2b0832d87f6ade149adda34